### PR TITLE
Add interactive release notes for MicroPython v1.24-v1.28

### DIFF
--- a/_includes/release-notes/boards-grid.html
+++ b/_includes/release-notes/boards-grid.html
@@ -1,0 +1,16 @@
+<section class="section" id="boards">
+  <div class="section-header">
+    <h2>New Boards</h2>
+    <p class="section-desc">{{ page.boards.summary }}</p>
+  </div>
+  <div class="board-gallery">
+    {% for group in page.boards.groups %}
+    <div class="board-port-group">
+      <h4>{{ group.port }}</h4>
+      <div class="board-list">
+        {% for board in group.boards %}<span class="board-chip">{{ board }}</span>{% endfor %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</section>

--- a/_includes/release-notes/by-the-numbers.html
+++ b/_includes/release-notes/by-the-numbers.html
@@ -1,0 +1,46 @@
+<section class="section" id="numbers">
+  <div class="section-header">
+    <h2>By the Numbers</h2>
+    <p class="section-desc">{{ page.numbers.summary }}</p>
+  </div>
+
+  <div class="numbers-grid">
+    {% for card in page.numbers.cards %}
+    <div class="number-card">
+      <span class="big-number counter" data-target="{{ card.value }}">0</span>
+      <div class="number-label">{{ card.label }}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  {% if page.numbers.code_size %}
+  <div class="code-size-chart">
+    <h3>{{ page.numbers.code_size.title | default: "Code Size Impact" }}</h3>
+    {% for row in page.numbers.code_size.rows %}
+    <div class="cs-row">
+      <div class="cs-name">{{ row.port }}</div>
+      <div class="cs-bar-wrap">
+        {% if row.delta_bytes < 0 %}
+          <div class="cs-bar negative" style="width: {{ row.bar_pct }}%;"></div>
+        {% else %}
+          <div class="cs-bar positive" style="width: {{ row.bar_pct }}%;"></div>
+        {% endif %}
+        {% if row.tooltip %}<div class="cs-tooltip">{{ row.tooltip }}</div>{% endif %}
+      </div>
+      <div class="cs-value">{% if row.delta_bytes > 0 %}+{% endif %}{{ row.delta_bytes }} B</div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if page.numbers.contributors %}
+  <div style="margin-top:32px; text-align:center;">
+    <button id="contributors-btn" class="contributors-toggle" onclick="toggleContributors()">
+      Show all contributors
+    </button>
+    <div id="contributors-list" class="contributors-list">
+      {{ page.numbers.contributors }}
+    </div>
+  </div>
+  {% endif %}
+</section>

--- a/_includes/release-notes/footer.html
+++ b/_includes/release-notes/footer.html
@@ -1,0 +1,17 @@
+<footer class="footer">
+  <div class="footer-links">
+    <a href="https://github.com/micropython/micropython/releases/tag/{{ page.hero.version }}.0" target="_blank">CHANGELOG on GitHub</a>
+    <a href="https://docs.micropython.org/" target="_blank">Documentation</a>
+    <a href="https://micropython.org/download/" target="_blank">Downloads</a>
+    <a href="https://github.com/micropython/micropython" target="_blank">Source</a>
+  </div>
+  <div class="funding">
+    <strong>MicroPython</strong> is a free and open-source project, supported by individual donations and corporate sponsors.<br>
+    <a href="https://github.com/sponsors/micropython" target="_blank">GitHub Sponsors</a> &middot;
+    <a href="https://opencollective.com/micropython" target="_blank">Open Collective</a>
+  </div>
+  <p style="font-size:12px; color:var(--text-muted); margin-top:24px;">
+    Page rebuilt by <a href="https://melbournemicropythonmeetup.github.io/">Melbourne MicroPython Meetup</a>.
+    {% if page.pyscript %}Interactive examples powered by <a href="https://pyscript.net/" target="_blank">PyScript</a>.{% endif %}
+  </p>
+</footer>

--- a/_includes/release-notes/hero.html
+++ b/_includes/release-notes/hero.html
@@ -1,0 +1,6 @@
+<section class="hero" id="hero">
+  {% if page.hero.badge %}<div class="hero-badge">{{ page.hero.badge }}</div>{% endif %}
+  <h1>MicroPython <span>{{ page.hero.version }}</span></h1>
+  <p class="hero-tagline">{{ page.hero.tagline }}</p>
+  <p class="hero-date">Released {{ page.hero.date }}</p>
+</section>

--- a/_includes/release-notes/mpy-banner.html
+++ b/_includes/release-notes/mpy-banner.html
@@ -1,0 +1,7 @@
+<div class="mpy-banner">
+  <span class="mpy-banner-icon">&#9889;</span>
+  <div class="mpy-banner-text">
+    <strong>{{ page.mpy_banner.headline }}</strong>
+    {{ page.mpy_banner.body }}
+  </div>
+</div>

--- a/_includes/release-notes/sidebar.html
+++ b/_includes/release-notes/sidebar.html
@@ -1,0 +1,14 @@
+<nav class="sidebar" id="sidebar">
+  <div class="sidebar-logo">MicroPython</div>
+  <div class="sidebar-version">{{ page.version }} Release Notes</div>
+  <ul class="toc">
+    <li><a href="#hero" data-section="hero">Overview</a></li>
+    <div class="toc-divider"></div>
+    {% for section in page.toc %}
+    <li><a href="#{{ section.id }}" data-section="{{ section.id }}">{{ section.label }}</a></li>
+    {% endfor %}
+    <div class="toc-divider"></div>
+    {% if page.boards %}<li><a href="#boards" data-section="boards">New Boards</a></li>{% endif %}
+    {% if page.numbers %}<li><a href="#numbers" data-section="numbers">By the Numbers</a></li>{% endif %}
+  </ul>
+</nav>

--- a/_includes/release-notes/stats-ribbon.html
+++ b/_includes/release-notes/stats-ribbon.html
@@ -1,0 +1,8 @@
+<div class="stats-ribbon">
+  {% for stat in page.stats %}
+  <div class="stat-item">
+    <span class="stat-number counter" data-target="{{ stat.value }}">0</span>
+    <span class="stat-label">{{ stat.label }}</span>
+  </div>
+  {% endfor %}
+</div>

--- a/_includes/release-notes/summary-cards.html
+++ b/_includes/release-notes/summary-cards.html
@@ -1,0 +1,9 @@
+<div class="summary-cards">
+  {% for card in page.summary_cards %}
+  <a class="summary-card" href="#{{ card.target }}" style="text-decoration:none">
+    <span class="card-icon">{{ card.icon }}</span>
+    <div class="card-title">{{ card.title }}</div>
+    <div class="card-desc">{{ card.desc }}</div>
+  </a>
+  {% endfor %}
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,7 @@
 
           <nav>
             <a href="{{ site.baseurl }}/">Blog</a>
+            <a href="{{ site.baseurl }}/releases/">Release Notes</a>
             <a href="{{ site.baseurl }}/about">About</a>
           </nav>
         </header>

--- a/_layouts/release-notes.html
+++ b/_layouts/release-notes.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ page.title }}</title>
+<link rel="stylesheet" href="{{ '/assets/css/release-notes.css' | relative_url }}">
+{% if page.page_css %}<link rel="stylesheet" href="{{ page.page_css | relative_url }}">{% endif %}
+{% if page.extra_css %}<style>{{ page.extra_css }}</style>{% endif %}
+{% if page.pyscript %}
+<link rel="stylesheet" href="https://pyscript.net/releases/2026.3.1/core.css">
+<script type="module" src="https://pyscript.net/releases/2026.3.1/core.js"></script>
+{% endif %}
+</head>
+<body>
+
+<button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">
+  <span id="theme-icon">&#9790;</span>
+</button>
+
+<button class="mobile-menu-btn" onclick="toggleSidebar()">&#9776;</button>
+
+{% include release-notes/sidebar.html %}
+
+<div class="main">
+
+  {% include release-notes/hero.html %}
+
+  {% if page.summary_cards %}{% include release-notes/summary-cards.html %}{% endif %}
+
+  {% if page.stats %}{% include release-notes/stats-ribbon.html %}{% endif %}
+
+  {% if page.mpy_banner %}{% include release-notes/mpy-banner.html %}{% endif %}
+
+  {{ content }}
+
+  {% if page.boards %}{% include release-notes/boards-grid.html %}{% endif %}
+
+  {% if page.numbers %}{% include release-notes/by-the-numbers.html %}{% endif %}
+
+  {% include release-notes/footer.html %}
+
+</div>
+
+{% if page.pyscript_block %}
+<script type="mpy">
+{{ page.pyscript_block }}
+</script>
+{% endif %}
+
+<script src="{{ '/assets/js/release-notes.js' | relative_url }}"></script>
+{% if page.page_js %}<script src="{{ page.page_js | relative_url }}"></script>{% endif %}
+{% if page.extra_js %}<script>{{ page.extra_js }}</script>{% endif %}
+
+</body>
+</html>

--- a/assets/css/release-notes.css
+++ b/assets/css/release-notes.css
@@ -1,0 +1,1078 @@
+/* ============================================================
+   MicroPython Release Notes — shared stylesheet
+   Origin: extracted verbatim from micropython-v1.28/index.html
+   Per-release pages add their own bespoke demo CSS on top.
+   ============================================================ */
+
+/* ===== CSS Reset & Variables ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace;
+  --max-width: 900px;
+  --sidebar-width: 220px;
+  --transition: 0.3s ease;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --bg-card: #1c2129;
+  --bg-code: #1a1e25;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+  --accent: #58a6ff;
+  --accent-glow: rgba(88, 166, 255, 0.15);
+  --accent-green: #3fb950;
+  --accent-green-glow: rgba(63, 185, 80, 0.15);
+  --accent-orange: #d29922;
+  --accent-red: #f85149;
+  --accent-purple: #bc8cff;
+  --border: #30363d;
+  --border-highlight: #58a6ff;
+  --shadow: 0 2px 12px rgba(0,0,0,0.4);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
+  --pwm-high: #3fb950;
+  --pwm-low: #21262d;
+  --pwm-line: #58a6ff;
+}
+
+[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f6f8fa;
+  --bg-tertiary: #eaeef2;
+  --bg-card: #f6f8fa;
+  --bg-code: #f0f3f6;
+  --text-primary: #1f2328;
+  --text-secondary: #656d76;
+  --text-muted: #8b949e;
+  --accent: #0969da;
+  --accent-glow: rgba(9, 105, 218, 0.1);
+  --accent-green: #1a7f37;
+  --accent-green-glow: rgba(26, 127, 55, 0.1);
+  --accent-orange: #9a6700;
+  --accent-red: #cf222e;
+  --accent-purple: #8250df;
+  --border: #d0d7de;
+  --border-highlight: #0969da;
+  --shadow: 0 2px 8px rgba(0,0,0,0.08);
+  --shadow-lg: 0 8px 24px rgba(0,0,0,0.12);
+  --pwm-high: #1a7f37;
+  --pwm-low: #eaeef2;
+  --pwm-line: #0969da;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background var(--transition), color var(--transition);
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ===== Theme Toggle ===== */
+.theme-toggle {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  transition: all var(--transition);
+  color: var(--text-primary);
+}
+.theme-toggle:hover { border-color: var(--accent); }
+
+/* ===== Sidebar / TOC ===== */
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: var(--sidebar-width);
+  height: 100vh;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  padding: 24px 16px;
+  overflow-y: auto;
+  z-index: 100;
+  transition: transform 0.3s ease, background var(--transition);
+}
+
+.sidebar-logo {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.sidebar-version {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 24px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.toc { list-style: none; }
+.toc li { margin-bottom: 2px; }
+.toc a {
+  display: block;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+  border-left: 2px solid transparent;
+}
+.toc a:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  text-decoration: none;
+}
+.toc a.active {
+  color: var(--accent);
+  background: var(--accent-glow);
+  border-left-color: var(--accent);
+  font-weight: 600;
+}
+.toc-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 12px 10px;
+}
+
+.mobile-menu-btn {
+  display: none;
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 1001;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: 20px;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ===== Main Content ===== */
+.main {
+  margin-left: var(--sidebar-width);
+  max-width: calc(var(--max-width) + 80px);
+  padding: 0 40px;
+}
+
+/* ===== Hero Section ===== */
+.hero {
+  padding: 80px 0 48px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0; left: -50%; right: -50%; bottom: 0;
+  background: radial-gradient(ellipse at 50% 0%, var(--accent-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--accent);
+  background: var(--accent-glow);
+  border: 1px solid var(--accent);
+  margin-bottom: 20px;
+  animation: pulse-border 3s ease-in-out infinite;
+}
+
+@keyframes pulse-border {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.3); }
+  50% { box-shadow: 0 0 0 8px rgba(88, 166, 255, 0); }
+}
+
+.hero h1 {
+  font-size: 48px;
+  font-weight: 800;
+  letter-spacing: -1px;
+  margin-bottom: 12px;
+  line-height: 1.1;
+}
+.hero h1 span { color: var(--accent); }
+
+.hero-tagline {
+  font-size: 18px;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto 16px;
+}
+
+.hero-date {
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+/* ===== Summary Cards ===== */
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin: 0 0 16px;
+}
+
+.summary-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
+}
+.summary-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+.summary-card .card-icon {
+  font-size: 28px;
+  margin-bottom: 8px;
+  display: block;
+}
+.summary-card .card-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.summary-card .card-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+/* Stats ribbon */
+.stats-ribbon {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  padding: 20px 0 40px;
+  flex-wrap: wrap;
+}
+.stat-item {
+  text-align: center;
+}
+.stat-number {
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--accent);
+  display: block;
+}
+.stat-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* ===== Section Styling ===== */
+.section {
+  padding: 64px 0;
+  border-top: 1px solid var(--border);
+}
+
+.section-header {
+  margin-bottom: 32px;
+}
+.section-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+.section-badge.new {
+  color: var(--accent-green);
+  background: var(--accent-green-glow);
+}
+.section-badge.improved {
+  color: var(--accent-orange);
+  background: rgba(210, 153, 34, 0.15);
+}
+
+.section h2 {
+  font-size: 32px;
+  font-weight: 800;
+  margin-bottom: 8px;
+  letter-spacing: -0.5px;
+}
+
+.section-desc {
+  font-size: 16px;
+  color: var(--text-secondary);
+  max-width: 700px;
+  margin-bottom: 24px;
+}
+
+/* ===== Code Blocks ===== */
+.code-block {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 16px 0;
+  position: relative;
+}
+.code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.copy-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: 11px;
+  transition: all 0.2s;
+}
+.copy-btn:hover { color: var(--text-primary); border-color: var(--accent); }
+.copy-btn.copied { color: var(--accent-green); border-color: var(--accent-green); }
+
+pre {
+  padding: 16px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+/* Syntax highlighting */
+.kw { color: var(--accent-purple); font-weight: 600; }
+.fn { color: #d2a8ff; }
+.str { color: #a5d6ff; }
+.num { color: #79c0ff; }
+.cmt { color: var(--text-muted); font-style: italic; }
+.op { color: var(--accent-red); }
+.bi { color: #ffa657; }
+
+[data-theme="light"] .kw { color: #8250df; }
+[data-theme="light"] .fn { color: #8250df; }
+[data-theme="light"] .str { color: #0a3069; }
+[data-theme="light"] .num { color: #0550ae; }
+[data-theme="light"] .cmt { color: #6e7781; }
+[data-theme="light"] .op { color: #cf222e; }
+[data-theme="light"] .bi { color: #953800; }
+
+/* ===== Demo Containers ===== */
+.demo-container {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  margin: 24px 0;
+  box-shadow: var(--shadow);
+}
+.demo-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+/* ===== Generic Buttons ===== */
+.btn {
+  padding: 8px 18px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition: all 0.2s;
+  font-family: var(--font-sans);
+}
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.btn-primary:hover { opacity: 0.85; }
+.btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+.btn-secondary:hover { border-color: var(--accent); }
+
+/* ===== Generic Badges ===== */
+.badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+.badge.active {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+  background: var(--accent-green-glow);
+}
+.badge.coming {
+  border-color: var(--accent-orange);
+  color: var(--accent-orange);
+}
+
+/* ===== Callouts ===== */
+.callout {
+  background: var(--accent-glow);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-top: 20px;
+  font-size: 14px;
+}
+.callout-title {
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 4px;
+  font-size: 13px;
+}
+
+/* ===== Port Matrix ===== */
+.port-matrix {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+  margin-top: 20px;
+}
+.port-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+.port-chip .check {
+  color: var(--accent-green);
+  font-weight: bold;
+}
+.port-chip.new-in-release {
+  border-color: var(--accent-green);
+  background: var(--accent-green-glow);
+  animation: chip-glow 2s ease-in-out 1;
+}
+@keyframes chip-glow {
+  0% { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.4); }
+  50% { box-shadow: 0 0 12px 4px rgba(63, 185, 80, 0.2); }
+  100% { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0); }
+}
+
+/* ===== Highlights Grid ===== */
+.highlights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.highlight-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  transition: all 0.2s ease;
+  cursor: default;
+}
+.highlight-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+.highlight-card .hl-icon {
+  font-size: 24px;
+  margin-bottom: 10px;
+  display: block;
+}
+.highlight-card h3 {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+.highlight-card p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.highlight-card .hl-ports {
+  display: flex;
+  gap: 4px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+.highlight-card .hl-port-tag {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+/* ===== By the Numbers ===== */
+.numbers-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-bottom: 32px;
+}
+.number-card {
+  text-align: center;
+  padding: 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.number-card .big-number {
+  font-size: 48px;
+  font-weight: 800;
+  color: var(--accent);
+  display: block;
+  font-variant-numeric: tabular-nums;
+}
+.number-card .number-label {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.code-size-chart {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 24px;
+}
+.code-size-chart h3 {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.cs-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 80px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.cs-row:last-child { border-bottom: none; }
+.cs-name {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
+}
+.cs-bar-wrap {
+  height: 20px;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.cs-bar {
+  height: 14px;
+  border-radius: 3px;
+  transition: width 1s ease;
+  position: relative;
+}
+.cs-bar.positive { background: var(--accent-orange); }
+.cs-bar.negative { background: var(--accent-green); }
+.cs-value {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: right;
+}
+.cs-bar-wrap .cs-tooltip {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 11px;
+  white-space: nowrap;
+  z-index: 10;
+  box-shadow: var(--shadow);
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.cs-row:hover .cs-tooltip { display: block; }
+
+/* ===== Board Gallery ===== */
+.board-gallery {
+  margin-top: 16px;
+}
+.board-port-group {
+  margin-bottom: 16px;
+}
+.board-port-group h4 {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.board-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.board-chip {
+  padding: 6px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  transition: all 0.2s;
+}
+.board-chip:hover {
+  border-color: var(--accent);
+  background: var(--accent-glow);
+}
+
+/* ===== Footer ===== */
+.footer {
+  padding: 48px 0;
+  border-top: 1px solid var(--border);
+  text-align: center;
+}
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.footer-links a {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+.footer-links a:hover { color: var(--accent); }
+
+.funding {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.8;
+}
+.funding strong { color: var(--text-secondary); }
+
+.contributors-toggle {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 13px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-family: var(--font-sans);
+  transition: all 0.2s;
+}
+.contributors-toggle:hover { border-color: var(--accent); }
+
+.contributors-list {
+  display: none;
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 2;
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.contributors-list.open { display: block; }
+
+/* ===== Responsive ===== */
+@media (max-width: 1024px) {
+  .sidebar { transform: translateX(-100%); }
+  .sidebar.open { transform: translateX(0); }
+  .mobile-menu-btn { display: flex; }
+  .main { margin-left: 0; }
+}
+
+@media (max-width: 768px) {
+  .hero h1 { font-size: 32px; }
+  .summary-cards { grid-template-columns: repeat(2, 1fr); }
+  .numbers-grid { grid-template-columns: 1fr; }
+  .cs-row { grid-template-columns: 80px 1fr 60px; }
+  .main { padding: 0 20px; }
+}
+
+@media (max-width: 480px) {
+  .summary-cards { grid-template-columns: 1fr; }
+  .stats-ribbon { gap: 16px; }
+}
+
+/* ===== PyScript Editor Overrides ===== */
+.live-playground {
+  margin-top: 24px;
+}
+.live-playground .demo-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.live-playground .demo-label .pyscript-tag {
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--accent-green-glow);
+  color: var(--accent-green);
+  border: 1px solid var(--accent-green);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+.playground-intro {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+.playground-group {
+  margin-bottom: 24px;
+}
+.playground-group h4 {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--text-primary);
+}
+.playground-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 8px;
+  font-style: italic;
+}
+
+/* Live editor + output panels */
+.mpy-code-editor {
+  width: 100%;
+  min-height: 120px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px 8px 0 0;
+  background: var(--bg-code);
+  color: var(--text-primary);
+  tab-size: 4;
+  resize: vertical;
+  outline: none;
+  display: block;
+}
+.mpy-code-editor:focus {
+  border-color: var(--accent);
+}
+.mpy-btn-row {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  align-items: center;
+}
+.mpy-btn-row .mpy-run-btn {
+  padding: 5px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent-green);
+  color: #fff;
+  transition: opacity 0.2s;
+}
+.mpy-btn-row .mpy-run-btn:hover { opacity: 0.85; }
+.mpy-btn-row .mpy-clear-btn {
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  transition: all 0.2s;
+}
+.mpy-btn-row .mpy-clear-btn:hover { border-color: var(--accent); color: var(--text-primary); }
+.mpy-btn-row .mpy-status {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.mpy-output {
+  margin-top: 8px;
+  padding: 12px;
+  min-height: 20px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  background: var(--bg-code);
+  color: var(--accent-green);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.mpy-output:empty { display: none; }
+.mpy-output.has-error { color: var(--accent-red); }
+
+.mpy-banner {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.mpy-banner-icon {
+  font-size: 32px;
+  flex-shrink: 0;
+}
+.mpy-banner-text {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.mpy-banner-text strong {
+  color: var(--text-primary);
+}
+.mpy-banner-text code {
+  background: var(--bg-tertiary);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+/* ===== Port Tier Chart =====
+   Originally lifted from the v1.27 release-notes page; reusable on the
+   /releases/ index as a "browse by port" navigation widget. */
+.tier-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.tier-legend-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.tier-legend-btn:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+.tier-legend-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.tier-legend-btn.active .tier-swatch {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.tier-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
+.tier-swatch.tier-1 { background: var(--accent-green); }
+.tier-swatch.tier-2 { background: var(--accent); }
+.tier-swatch.tier-3 { background: var(--accent-orange); }
+.tier-swatch.tier-M { background: var(--text-muted); }
+
+.tier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.tier-node {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  border-left-width: 4px;
+  transition: all 0.3s ease;
+  position: relative;
+}
+.tier-node.tier-1 { border-left-color: var(--accent-green); }
+.tier-node.tier-2 { border-left-color: var(--accent); }
+.tier-node.tier-3 { border-left-color: var(--accent-orange); }
+.tier-node.tier-M { border-left-color: var(--text-muted); }
+.tier-node.dimmed { opacity: 0.18; }
+.tier-node[data-vendor="true"]::after {
+  content: "*";
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  color: var(--accent-orange);
+  font-weight: 700;
+}
+
+.tier-node-name {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.tier-node-target {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  min-height: 28px;
+}
+.tier-node-tag {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  margin-top: 8px;
+  font-weight: 700;
+}
+
+/* Release-version chips on each port node (used on /releases/ index) */
+.tier-node-releases {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--border);
+}
+.tier-release-chip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all 0.15s;
+}
+.tier-release-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  text-decoration: none;
+}
+.tier-release-chip.unbuilt {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.tier-release-chip.unbuilt:hover {
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+.tier-summary {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  flex-wrap: wrap;
+  padding: 16px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.tier-summary strong {
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  margin-right: 4px;
+}
+.tier-summary-total {
+  border-left: 1px solid var(--border);
+  padding-left: 24px;
+}
+.tier-summary-total strong {
+  color: var(--text-primary);
+}
+
+.tier-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 16px;
+  font-style: italic;
+}

--- a/assets/js/release-notes.js
+++ b/assets/js/release-notes.js
@@ -1,0 +1,129 @@
+/* ============================================================
+   MicroPython Release Notes — shared behaviour
+   Theme toggle, sidebar, scrollspy, copy-button, animated
+   counters, contributors toggle. Per-page bespoke demos listen
+   for the 'themechange' CustomEvent on document for redraws.
+   ============================================================ */
+
+// ===== Theme Toggle =====
+function toggleTheme() {
+  const html = document.documentElement;
+  const current = html.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  html.setAttribute('data-theme', next);
+  const icon = document.getElementById('theme-icon');
+  if (icon) icon.innerHTML = next === 'dark' ? '&#9790;' : '&#9728;';
+  document.dispatchEvent(new CustomEvent('themechange', { detail: { theme: next } }));
+}
+
+// ===== Mobile Sidebar Toggle =====
+function toggleSidebar() {
+  const sidebar = document.getElementById('sidebar');
+  if (sidebar) sidebar.classList.toggle('open');
+}
+
+// ===== Scrollspy =====
+function initScrollspy() {
+  const sections = document.querySelectorAll('.section, .hero');
+  const tocLinks = document.querySelectorAll('.toc a');
+  if (!sections.length || !tocLinks.length) return;
+
+  const scrollObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const id = entry.target.id;
+        tocLinks.forEach(link => {
+          link.classList.toggle('active', link.getAttribute('data-section') === id);
+        });
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+
+  sections.forEach(section => scrollObserver.observe(section));
+
+  // Close sidebar on mobile when clicking a TOC link
+  tocLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      if (window.innerWidth <= 1024) {
+        const sidebar = document.getElementById('sidebar');
+        if (sidebar) sidebar.classList.remove('open');
+      }
+    });
+  });
+}
+
+// ===== Copy Code =====
+function copyCode(btn) {
+  const pre = btn.closest('.code-block').querySelector('pre');
+  const text = pre.textContent;
+  navigator.clipboard.writeText(text).then(() => {
+    btn.textContent = 'Copied!';
+    btn.classList.add('copied');
+    setTimeout(() => {
+      btn.textContent = 'Copy';
+      btn.classList.remove('copied');
+    }, 2000);
+  });
+}
+
+// ===== Animated Counters =====
+function initCounters() {
+  const counters = document.querySelectorAll('.counter');
+  if (!counters.length) return;
+
+  const counterObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        const target = parseInt(el.getAttribute('data-target'), 10);
+        const duration = 1200;
+        const start = performance.now();
+        function tick(time) {
+          const progress = Math.min((time - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3);
+          el.textContent = Math.round(target * eased);
+          if (progress < 1) requestAnimationFrame(tick);
+        }
+        requestAnimationFrame(tick);
+        counterObserver.unobserve(el);
+      }
+    });
+  }, { threshold: 0.5 });
+
+  counters.forEach(c => counterObserver.observe(c));
+}
+
+// ===== Contributors Toggle =====
+function toggleContributors() {
+  const list = document.getElementById('contributors-list');
+  const btn = document.getElementById('contributors-btn');
+  if (!list || !btn) return;
+  list.classList.toggle('open');
+  btn.textContent = list.classList.contains('open')
+    ? 'Hide contributor list'
+    : 'Show all contributors';
+}
+
+// ===== Port Tier Chart =====
+// Filter the .tier-grid by clicking .tier-legend-btn[data-tier]. Used on
+// the v1.27 page and on the /releases/ index "browse by port" widget.
+function initTierChart() {
+  const buttons = document.querySelectorAll('.tier-legend-btn');
+  const nodes = document.querySelectorAll('.tier-node');
+  if (!buttons.length || !nodes.length) return;
+
+  function setFilter(tier) {
+    buttons.forEach(b => b.classList.toggle('active', b.dataset.tier === tier));
+    nodes.forEach(n => {
+      n.classList.toggle('dimmed', tier !== 'all' && n.dataset.tier !== tier);
+    });
+  }
+  buttons.forEach(b => b.addEventListener('click', () => setFilter(b.dataset.tier)));
+}
+
+// ===== Bootstrap =====
+document.addEventListener('DOMContentLoaded', () => {
+  initScrollspy();
+  initCounters();
+  initTierChart();
+});

--- a/context/research/micropython-releases-v1.24-v1.28-digest.md
+++ b/context/research/micropython-releases-v1.24-v1.28-digest.md
@@ -1,0 +1,253 @@
+# MicroPython Releases v1.24 - v1.28 Digest
+
+Source material: annotated tag messages in `/tmp/mpy-tags/v1.24.0.txt`, `v1.24.1.txt`, `v1.25.0.txt`, `v1.26.0.txt`, `v1.26.1.txt`, `v1.27.0.txt`, `v1.28.0.txt`. The v1.28 tag was read briefly to calibrate against the existing `/micropython-v1.28/index.html` page, which uses bespoke canvas/SVG demos for hardware features (PWM waveform, CAN bus animation, GC weakref visual) and live PyScript playgrounds for pure-Python features (t-strings).
+
+Tier definitions used below:
+- **Tier A** - bespoke canvas/SVG/animation. Best for visualising hardware behaviour, time-series, register state, packet flow, etc.
+- **Tier B** - PyScript live playground. Feature must run on the `webassembly` port: language features, stdlib additions, `asyncio`, networking-as-data, etc.
+- **Tier C** - annotated code diff or static example. Port matrix, before/after snippets, architecture diagram.
+
+---
+
+## v1.24.0 - "RP2350 and ESP32-C6 support, RISC-V native emitter, common TinyUSB code"
+
+**Released**: 2024 (date not in tag; matches GitHub release log).
+**Headline tagline**: *"RISC-V grows up, RP2350 lands, and TinyUSB gets unified."*
+
+### Top headline features
+
+1. **RP2350 support (rp2 port)** - pico-sdk v2.0.0 brings the new MCU in both ARM and RISC-V modes, in 30- and 48-pin variants. New `RPI_PICO2` board, IPv6 enabled by default, USB stays active during `lightsleep()`.
+2. **ESP32-C6 support + RISC-V native emitter (esp32 port)** - Updated to ESP-IDF v5.2.2, RV32IMC native code generation enabled on C3 and C6. New `ESP32_GENERIC_C6`, `M5STACK_NANOC6`, `UM_TINYC6` boards.
+3. **`micropython.RingIO`** - new thread-safe byte-oriented ring buffer with a stream interface. Cross-port (core).
+4. **Unified TinyUSB CDC + portable UART IRQ API** - shared CDC code across esp32 (S2/S3), mimxrt, renesas-ra, rp2 and samd. Startup CDC data is now buffered and flushed on host connection (REPL banner appears on first connect). Consistent UART IRQ callbacks (`IRQ_RX`, `IRQ_RXIDLE`, `IRQ_TXIDLE`, `IRQ_BREAK`) on most ports.
+5. **`network.ipconfig()` + `network.PPP`** - new IPv4/IPv6 config API replacing `ifconfig()`; portable lwIP-based PPP available on rp2 and stm32.
+6. **f-string concatenation + raw f-strings** (core language). Plus `sys.exit()` now triggers a soft reset (breaking change).
+
+### By the numbers
+- **~58 contributors** named.
+- **~10 new boards**: 8 esp32 (`ESP32_GENERIC_C6`, `M5STACK_ATOMS3_LITE`, `M5STACK_NANOC6`, `OLIMEX_ESP32_EVB`, `UM_FEATHERS3NEO`, `UM_OMGS3`, `UM_RGBTOUCH_MINI`, `UM_TINYC6`), 1 rp2 (`RPI_PICO2`), 1 stm32 (`ARDUINO_OPTA`).
+- esp32 code size **shrank ~3.1%** (-53kB) - notable thanks to ESP-IDF cleanup.
+- Contributor timezones: 15 distinct (-0700 through +1100).
+
+### Demo proposals
+
+| Feature | Tier | Notes |
+|---|---|---|
+| f-string concat + raw f-strings | **B** | Pure language, runs on `webassembly`. Side-by-side: pre-1.24 paste vs 1.24+ paste, hit Run, watch identical output. Trivial PyScript win. |
+| `sys.exit()` -> soft reset | **B** | Demonstrable in PyScript with caveat (no real "device" to reset, but show the SystemExit flow). Could just be Tier C if too confusing. |
+| `micropython.RingIO` | **B** | Pure-Python visible API, available on `webassembly`. Live producer/consumer playground; could pair with a Tier-A oscilloscope-style canvas of the buffer fill level. |
+| RP2350 / ESP32-C6 | **A** | Bespoke MCU comparison card: side-by-side spec strip (cores, RAM, RISC-V/ARM toggle for RP2350). Animated "ARM <-> RISC-V" toggle is a great visual hook. |
+| RISC-V native emitter | **C** | Show `@micropython.native` snippet, port-availability matrix (rp2 RISC-V, esp32 C3/C6, qemu). Probably no useful interactivity. |
+| TinyUSB CDC unification | **C** | Annotated diagram of which ports now share code; before/after of the "missing REPL banner on first connect" gotcha. Hard to demo live. |
+| `network.ipconfig()` | **C** | Static side-by-side: old `nic.ifconfig((ip, mask, gw, dns))` vs new `nic.ipconfig(addr4=...)`. IPv6 support is a key talking point. |
+| UART IRQ API + PPP | **C** | Port matrix; static. |
+
+### Watch-outs / open questions
+- `sys.exit()` behaviour change is genuinely breaking - need to lead with the warning, not bury it.
+- "RISC-V native emitter" overlaps with v1.25's inline RV32 assembler; need to decide which release "owns" the RISC-V hero narrative.
+- `qemu-arm` -> `qemu` rename is interesting trivia but probably not section-worthy.
+
+---
+
+## v1.24.1 (point release, 2024)
+
+One-liner: small grab-bag patch - mpremote `fs_writefile` UnboundLocalError fix, esp32 PWM resolution + ESP-IDF v5.0/5.1 PWM regression, `objdeque` buffer overflow, lwIP IGMP IPv6, `FrameBuffer.ellipse` zero-radius bug, ESP32-S2 native code crash workaround. **Skip on the page** unless we want a "patches" footnote.
+
+---
+
+## v1.25.0 - "ROMFS, alif port, RISCV inline assembler, DTLS, mpremote recursive remove"
+
+**Released**: early 2025.
+**Headline tagline**: *"After three years cooking, ROMFS ships - plus a brand new ML-capable port."*
+
+### Top headline features
+
+1. **ROMFS / VfsRom** - long-awaited (cited *"more than three years in development"*). Read-only, memory-mappable filesystem, executes bytecode in-place without copying to RAM. Imports become *significantly* faster, fonts/data usable in-place. Enabled on PYBD-SFx, all alif boards, an `ESP8266_GENERIC FLASH_2M_ROMFS` variant, and all stm32 Arduino boards. Driven via new `mpremote romfs query/build/deploy`.
+2. **alif port (new)** - support for Alif Ensemble MCUs with multi-core ARM + Ethos-U55 ML accelerators. TinyUSB, dual-core via OpenAMP, octal-SPI XIP, machine.{Pin,UART,SPI,I2C}, cyw43 WiFi+BLE. Boards: `ALIF_ENSEMBLE`, `OPENMV_AE3`.
+3. **`@micropython.asm_rv32` inline assembler** - write 32-bit RISC-V machine code inline in Python. Enabled on rp2 when RP2350 is in RISC-V mode.
+4. **DTLS support** - `tls.PROTOCOL_DTLS_CLIENT` / `..._SERVER` modes wrap UDP sockets. Enabled on alif, mimxrt, renesas-ra, rp2, stm32 and unix.
+5. **`marshal` module** - `dumps()`/`loads()` for code objects; combined with `function.__code__` lets you serialise functions to bytes. Not enabled by default but pure-Python visible.
+6. **mpremote `rm -r`** + recursive remove, plus support for relative URLs in `package.json`, local-fs mip install, faster `mount` readline.
+
+### By the numbers
+- **~50 contributors**.
+- **~21 new boards**: 2 alif, 1 mimxrt, 12 rp2 (lots of SparkFun + RP2350-class), 5 samd, 1 stm32.
+- Contributor timezones: 15.
+- mimxrt code size +2.06% (exFAT, function constructor); unix +2.05% (VfsRom + DTLS).
+
+### New boards
+- alif: `ALIF_ENSEMBLE`, `OPENMV_AE3`.
+- mimxrt: `MAKERDIARY_RT1011_NANO_KIT`.
+- rp2: `MACHDYNE_WERKZEUG`, `RPI_PICO2_W`, `SEEED_XIAO_RP2350`, `SPARKFUN_IOTNODE_LORAWAN_RP2350`, `SPARKFUN_IOTREDBOARD_RP2350`, `SPARKFUN_PROMICRO_RP2350`, `SPARKFUN_THINGPLUS_RP2350`, `SPARKFUN_XRP_CONTROLLER`, `SPARKFUN_XRP_CONTROLLER_BETA`, `WEACTSTUDIO_RP2350B_CORE`.
+- samd: `ADAFRUIT_NEOKEY_TRINKEY`, `ADAFRUIT_QTPY_SAMD21`, `SAMD_GENERIC_D21X18`, `SAMD_GENERIC_D51X19`, `SAMD_GENERIC_D51X2`.
+- stm32: `WEACT_F411_BLACKPILL`.
+
+### Demo proposals
+
+| Feature | Tier | Notes |
+|---|---|---|
+| ROMFS | **A** | Bespoke memory-map diagram: heap vs flash, animated arrow showing "import normally" copying bytecode -> RAM, then toggle to "import from ROMFS" with no copy. Could include a fake mpremote terminal showing `mpremote romfs build / deploy`. Strong visual story. |
+| alif port | **C** | Port spec card: cores, Ethos-U55 mention, supported peripherals, boards. Could cross-link to OpenMV AE3 marketing image. |
+| `@micropython.asm_rv32` | **C** | Annotated side-by-side: pure Python loop vs inline RV32 asm, with a "speedup" badge. Cannot run in PyScript (no RV32 native emitter on `webassembly`). |
+| DTLS | **C/A** | Tier C: code diff `PROTOCOL_TLS_CLIENT` -> `PROTOCOL_DTLS_CLIENT`. Could upgrade to Tier A with an animated UDP-with-handshake packet diagram. |
+| `marshal` module | **B** | Pure Python, runnable in PyScript pyscript variant. Live: define a function, `marshal.dumps(f.__code__)`, view bytes, `loads()` and run again. Caveat: needs to confirm `marshal` is enabled on the pyscript build - tag explicitly says *"not enabled by default"*. **OPEN QUESTION**. |
+| `str.startswith/endswith` tuples + start/end | **B** | Trivial PyScript demo. Bundle into a "Python language tweaks" sub-section. |
+| 2-arg `next()` | **B** | Trivial PyScript. Same sub-section. |
+| `vfs.mount()` no-args returns mount table | **B** | Runnable on webassembly if VFS is mounted there - **OPEN QUESTION** whether the pyscript variant exposes a mount table. |
+| `mpremote rm -r` / `romfs deploy` | **C** | Static animated terminal screencast (CSS keyframes typing). |
+
+### Watch-outs / open questions
+- ROMFS section is the obvious headline - but the underlying concept (memory-mapped bytecode v6) needs careful explanation. Worth a callout box on bytecode versions.
+- Confirm whether `marshal` is compiled into the PyScript pyscript variant before promising a Tier-B demo.
+- `webassembly port: no changes specific to this component/port` in v1.25 - so most v1.25 wins are inherited via core changes only. Demos must lean on language/stdlib features rather than port-specific ones.
+
+---
+
+## v1.26.0 - "I2CTarget, improved floats and native emitter, STM32N6 & ESP32C2 support"
+
+**Released**: mid 2025.
+**Headline tagline**: *"MicroPython gets serious about floating-point - and starts answering I2C, not just asking."*
+
+### Top headline features
+
+1. **`machine.I2CTarget`** - Python implements an I2C target/slave device. Simplest case binds an I2C register/memory device to a `bytearray`. More complex cases use IRQs from the class to handle arbitrary protocols. Available on **alif, esp32, mimxrt, rp2, samd, stm32, zephyr**.
+2. **Float accuracy overhaul** - repr-reversibility went from ~28%/38% (single/double) to **98.5%/99.8%**. Three layers: better float printing, compile-time float folding/`const`, and a heuristic for the lost low bits in OBJ_REPR_C.
+3. **STM32N6xx + ESP32-C2** - 800 MHz STM32N6 with ML accelerators, USB, XSPI memory-mapped flash; ESP32-C2 (aka ESP8684) low-cost RISC-V WiFi+BLE.
+4. **Native + viper emitter improvements** - more compact loads/stores across ARM, Thumb, Xtensa, RV32, x86, x64. Thumb v1 (RP2040) gets long jumps >12 bits, allowing larger Python functions to compile native. Xtensa inline asm gets most LX3 opcodes.
+5. **`esp32.PCNT` + `machine.Counter` / `machine.Encoder`** (esp32) - hardware pulse counting incl. quadrature encoders.
+6. **Slice-on-stack VM optimisation** - `bytearray_obj[a:b] = c` no longer allocates a slice on the heap; works inside hard ISRs and reduces churn.
+7. **Misc language**: `__all__` in star imports, PEP-487 `__set_name__`, `:_b/o/x` separators in `str.format`, arrays extendable from any iterable.
+
+### By the numbers
+- **~46 contributors**.
+- **~10 new boards** (lower than usual, attention was on infra).
+- **esp32 code size +1.12%** (+19 kB), driven by IDF v5.4.2 + I2CTarget.
+- Contributor timezones: 13.
+
+### New boards
+- esp32: `GARATRONIC_PYBSTICK26_ESP32C3`, `SPARKFUN_IOT_REDBOARD_ESP32`.
+- samd: `SPARKFUN_REDBOARD_TURBO`, `SPARKFUN_SAMD21_DEV_BREAKOUT`.
+- stm32: `NUCLEO_N657X0`, `OPENMV_N6`.
+- zephyr: `beagleplay_cc1352p7`, `nrf5340dk`, `nrf9151dk`, `rpi_pico`.
+
+### Demo proposals
+
+| Feature | Tier | Notes |
+|---|---|---|
+| `machine.I2CTarget` | **A** | Bespoke SVG: two MCUs on an I2C bus, controller writes to "register 0x10", target's bytearray updates live; click to flip controller/target roles. Best storytelling feature of the release. |
+| Float accuracy improvement | **B** | **Strong PyScript candidate.** Pure-Python: input a float, show old-style truncated repr vs new accurate repr (we'd need to fake the "before" with hand-rolled formatting, since the live build is "after"). Could pair with a live histogram of the 28%->98.5% reversibility stat. |
+| Float constant folding | **B** | PyScript: show `const(2 * math.pi)` folding behaviour; demonstrate via `dis`-like output if available. **OPEN QUESTION**: `dis` module on webassembly. |
+| Slice-on-stack | **C** | Annotated diff: `arr[1:5] = b'abcd'` - explain the hard-ISR implication, GC-free property. Tier B is possible but the visible behaviour is identical to the user, so Tier C is more honest. |
+| Native/viper emitter perf | **C** | Bar chart of code-size savings from tag (Thumb v1 +long jumps stat); architecture port matrix. |
+| STM32N6 / ESP32-C2 | **C** | Spec cards mirroring v1.24's RP2350 cards. STM32N6 ML accelerator angle is interesting. |
+| `esp32.PCNT` / Counter / Encoder | **A** | Bespoke quadrature-encoder canvas: drag a virtual knob, watch the count tick. Hardware-only feature so no Tier B option. esp32-only callout. |
+| `__set_name__` / `__all__` star import | **B** | Pure language. Bundle into a "Python language additions" sub-section with a single PyScript playground that swaps between examples. |
+| `str.format` `:_b/o/x` separators | **B** | One-line PyScript demo: `f"{0xdeadbeef:_x}"`. Trivial. |
+| DTLS HelloVerify + lwIP UDP queue | **C** | Static; not user-visible without networking. |
+| mpremote `fs tree` + `df` | **C** | Animated terminal recording. |
+
+### Watch-outs / open questions
+- I2CTarget's "Python responds to I2C" pitch needs careful framing - audiences will assume it's an I2C *controller*. Lead with "your microcontroller is now the slave/target".
+- The float accuracy story is technically dense (OBJ_REPR_C is internal). Need to focus on the user-visible "repr round-trips correctly now" outcome, not the heuristic.
+- `Counter`/`Encoder` are added in `modules/machine.py` (Python wrapper) on esp32; the API is currently esp32-only although it lives under `machine`. Worth noting it's *not* yet cross-port.
+
+---
+
+## v1.26.1 (point release)
+
+One-liner: ESP32 native USB stability - `esp_tinyusb` -> v1.7.6, USB CDC TX rewrite, mpremote DTR/RTS quirk fix for TinyUSB CDC. Also adds `MICROPY_MAINTAINER_BUILD` env var. **Worth a one-line footnote** for ESP32 users since the USB hang is a real-world bug.
+
+---
+
+## v1.27.0 - "ESP32C5, ESP32P4 & STM32U5 support, enhanced test suite, port Tier levels"
+
+**Released**: late 2025.
+**Headline tagline**: *"Three new MCU families, formal port tiers, and a unified REPL on every port."*
+
+### Top headline features
+
+1. **ESP32-C5 + ESP32-P4 support** - new RISC-V SoCs. P4 can run standalone or paired with a C5/C6 wireless co-processor; tag provides board profiles for all three configurations.
+2. **STM32U5xx series support** - low-power high-performance STM32; USB, ADC, DAC, UART, I2C, SPI, RTC. Board: `NUCLEO_U5A5ZJ_Q`.
+3. **Formal port Tier levels** - 20 ports categorised into 4 tiers; documented in README and at https://docs.micropython.org/en/latest/develop/support_tiers.html. Sets expectations for support and lowers the bar for new ports to land.
+4. **Test suite + CI overhaul** - auto-detection of unicode/float/native support, `target_wiring.py` for hardware-in-the-loop wiring config, all `machine.UART` tests converted, ASan/UBSan builds, full test suite on unix-minimal and zephyr CI, serial throughput test.
+5. **Unified REPL on unix/windows** - main REPL replaced with the bare-metal pyexec REPL. Adds raw-REPL support to unix/windows. Now `mpremote` works against unix builds the same as bare-metal.
+6. **Hard IRQ timer callbacks across ports** - most ports (except esp32) now support `hard=` for `machine.Timer`.
+7. **Drop Python 2.7 support** in build scripts.
+8. **Misc language**: relative imports in custom `__import__`, `bool`/`len` on dict views, start/end positions for `re.match`/`search`, IPv6 in `asyncio.start_server()`, `sys` module enabled at all feature levels by default.
+
+### By the numbers
+- **~50 contributors**.
+- **~10 new boards**: 5 esp32, 4 stm32, plus zephyr boards (PocketBeagle 2, XIAO BLE NRF52840 SENSE, NXP MIMXRT1020 EVK).
+- **esp32 code size +2.12%** (+36 kB) - dominated by ESP-IDF 5.5.1 bump.
+- Contributor timezones: 16 (-0800 to +1100).
+
+### New boards
+- esp32: `ESP32_GENERIC_C2 FLASH_2M`, `ESP32_GENERIC_C5`, `ESP32_GENERIC_P4` (+ `C5_WIFI`, `C6_WIFI` variants), `SIL_MANT1S`, `SOLDERED_NULA_MINI`.
+- stm32: `NUCLEO_H7A3ZI_Q`, `NUCLEO_U5A5ZJ_Q`, `STM32F469DISC`, `WEACTSTUDIO_MINI_STM32H743`.
+- zephyr: PocketBeagle 2 variants, XIAO BLE nRF52840 Sense, NXP MIMXRT1020 EVK.
+
+### Demo proposals
+
+| Feature | Tier | Notes |
+|---|---|---|
+| ESP32-P4 + co-processor | **A** | Bespoke SVG diagram: P4 standalone vs P4-with-C6-radio - clickable toggle revealing how the two chips talk. Strongest hardware visual of the release. |
+| STM32U5 | **C** | Spec card. Less inherently visual than P4. |
+| Port Tier levels | **A** | **Custom interactive port tier chart** - all 20 ports as nodes coloured by tier, hover for board count, tier description. Could double as the navigation widget for a `/releases/` index. |
+| `target_wiring.py` + test suite | **C** | Aimed at contributors. Annotated example file. Skip-able on a public-facing page unless we lean into "MicroPython quality" narrative. |
+| Hard IRQ timer callbacks | **C/A** | Tier C: port matrix of `hard=True` support. Tier A possible: side-by-side timeline showing soft vs hard IRQ jitter, but that's more a v1.26-era story. |
+| Unified unix REPL / raw REPL | **C** | Animated terminal: `mpremote run` against unix build. Mostly developer-experience. |
+| `re.match(start, end)` | **B** | Pure-Python PyScript demo. Trivial. |
+| `bool`/`len` on dict views | **B** | One-liner PyScript. Bundle. |
+| `asyncio.start_server()` IPv6 | **B** | PyScript probably can't bind a real socket; demote to **Tier C** code diff. |
+| Relative imports in custom `__import__` | **B** | PyScript demo - install a custom `__import__` hook, show relative resolution. Niche but cute. |
+| Drop Python 2.7 | **C** | Footnote. |
+
+### Watch-outs / open questions
+- Port Tier levels is a great organising idea for the `/releases/` index page itself - consider building the tier chart once and reusing.
+- ESP32-C5 vs ESP32-C6 vs ESP32-P4 will confuse non-ESP audiences. Clear naming/colour key needed.
+- `asyncio.start_server()` IPv6 - check whether the pyscript variant exposes any networking. If not, definitely Tier C.
+- Several "pure language" wins are small enough that a single combined "Language additions in v1.27" PyScript playground (with a dropdown to pick the example) is probably better than five tiny demos.
+
+---
+
+## v1.28.0 (already implemented - calibration only)
+
+**Tagline**: *"PWM on alif and stm32, new machine.CAN API, t-strings and weakref module."*
+The existing `/micropython-v1.28/index.html` page uses:
+- **PWM** -> Tier A (interactive frequency/duty canvas waveform)
+- **CAN** -> Tier A (animated SVG bus topology)
+- **t-strings** -> Tier B (live PyScript playground; explicitly enabled on the pyscript variant per tag)
+- **weakref** -> Tier A + B hybrid (interactive GC visualiser; `weakref` is *only* enabled on the pyscript variant per tag)
+
+Calibration takeaway: **the existing page leans hard into Tier A for hardware features and Tier B for language features**, with each section getting roughly equal real-estate. The PyScript playgrounds are textareas + Run buttons, not embedded REPLs - so the bar for a "Tier B" demo is "can be expressed as a self-contained ~10-line script". This matches what's proposed above.
+
+---
+
+## Cross-cutting analysis
+
+### Recurring themes across v1.24 -> v1.27
+
+1. **RISC-V march**: every release adds RV32 capability (v1.24 native emitter, v1.25 inline asm, v1.26 emitter optimisations, v1.27 Zba opcodes + RV64 qemu, v1.28 Zcmp). A "RISC-V journey" timeline could span the whole `/releases/` index.
+2. **ESP-IDF treadmill**: v5.2.2 (1.24) -> 5.3/5.4 (1.25) -> 5.4.2 (1.26) -> 5.5.1 (1.27). Each bump changes ESP32 code size visibly.
+3. **New STM32 families per release**: H7 octospi (1.24), N6 (1.26), U5 + F469 (1.27).
+4. **Native emitter / viper improvements** in every release - good candidate for a single cross-release "performance" article.
+5. **mpremote ergonomics**: hash-based recursive copy (1.24), `rm -r` + `romfs` (1.25), `fs tree` + better `df` + ESP CDC detection (1.26), DTR/RTS fixes (1.27).
+6. **`machine.*` API standardisation**: `ipconfig` (1.24), default I2C/SPI/UART buses (1.25), `I2CTarget` + `Counter`/`Encoder` (1.26), hard timers everywhere (1.27), `PWM` everywhere + `CAN` standardised (1.28). This is arguably *the* meta-narrative of the four releases.
+7. **Zephyr port maturation**: threading (1.24), `Timer`/`WDT` (1.25), PWM/UART/SPI/I2C (1.26), ADC + native FS VFS (1.27).
+8. **asyncio improvements** in every release (1.24 webassembly top-level await, 1.25 implicit, 1.26 scheduler fixes, 1.27 IPv6 server).
+9. **Floating point + native emitter accuracy** is a story specifically for 1.26 but builds on 1.25's compiler infrastructure.
+10. **TinyUSB consolidation**: started in 1.24 (CDC), continues in every release; in 1.27 even stm32 starts adopting TinyUSB optionally.
+
+### PyScript opportunity ranking (most -> least in-browser-runnable content)
+
+1. **v1.26.0 - HIGHEST.** Strong language additions (`__set_name__`, `__all__` in star import, `:_b/o/x` separators, slice-on-stack, array-from-iterable) plus the float accuracy story is genuinely interactive. The hardware features (`I2CTarget`, `Counter`) make excellent Tier-A counterpoints, but there's plenty for PyScript to chew on.
+2. **v1.25.0 - HIGH.** ROMFS itself is hardware-flavoured but `marshal`, multiple core language tweaks (`startswith` tuples, 2-arg `next`, `vfs.mount()` no-args, `sys.implementation._build`), and DTLS-as-API-shape all surface in PyScript. Caveat: needs to confirm `marshal` is in the pyscript variant build.
+3. **v1.27.0 - MEDIUM.** Several language additions (`re` start/end, dict-view `bool`/`len`, IPv6 in `asyncio.start_server`, relative imports in `__import__`, `sys` always available) but each one is small. The release's headline is hardware (ESP32-C5/P4, STM32U5) and meta (port tiers, test suite) - hard to PyScript. Best approach is one combined "language tweaks" playground.
+4. **v1.24.0 - LOWEST.** The headline features are all hardware/port-level (RP2350, ESP32-C6, RISC-V emitter, TinyUSB unification, UART IRQ, PPP, `ipconfig`). Pure-Python wins are limited to f-string concat, raw f-strings, `RingIO`, and the `sys.exit` semantics shift. Plenty of Tier-A material - and the explicit *"webassembly: better asyncio support, top-level await of Task and Event"* line makes top-level-await the standout PyScript demo for this release.
+
+### Recommendations for the `/releases/` index page
+
+- Use the v1.27 port Tier chart as the navigation widget itself - one click jumps to the release page where that port grew/changed.
+- A single "RISC-V across the releases" timeline at the top of the index ties all four releases together.
+- Each release page should keep the v1.28 layout: hero -> 3-5 sections (mix of A/B) -> "by the numbers" footer -> board grid.
+- Reuse a single PyScript bootstrap shared across pages - the pyscript variant build is the same for v1.25-v1.28 (v1.24 webassembly port had only "better asyncio" in the tag), so demos can target a recent build for older releases by acknowledging "this is what running it today looks like".

--- a/context/research/micropython-v1.26-page-layout.md
+++ b/context/research/micropython-v1.26-page-layout.md
@@ -1,0 +1,461 @@
+# MicroPython v1.26.0 — Interactive Release Notes Page Layout
+
+Section-by-section design for the proposed first build on the new shared infrastructure
+(`_layouts/release-notes.html` + `_includes/release-notes/*` + `assets/css/release-notes.css`
++ `assets/js/release-notes.js`).
+
+Source: `/tmp/mpy-tags/v1.26.0.txt` (annotated tag), and the cross-release digest at
+`context/research/micropython-releases-v1.24-v1.28-digest.md`.
+
+**Probe results that constrain this page**:
+- ❌ `marshal` not in pyscript variant (FULL_FEATURES, not EVERYTHING).
+- ❌ no `dis` module anywhere in MicroPython.
+- ✅ `function.__code__` available (FULL_FEATURES gates it).
+
+---
+
+## Page metadata (front-matter shape)
+
+Goes at the top of `micropython-v1.26/index.html`. Drives the shared layout.
+
+```yaml
+---
+layout: release-notes
+title: MicroPython v1.26.0 Release Notes
+version: v1.26.0
+pyscript: true
+
+hero:
+  badge: "Past Release"        # v1.28 says "New Release"; older releases get a different label
+  version: "v1.26"
+  tagline: "I2CTarget, the float-accuracy overhaul, native emitter wins, plus STM32N6 and ESP32-C2."
+  date: "August 9, 2025"
+
+summary_cards:
+  - { icon: "🔌", title: "machine.I2CTarget", desc: "Python responds on I2C", target: "i2ctarget" }
+  - { icon: "🎯", title: "Float accuracy", desc: "98.5% repr-reversibility", target: "floats" }
+  - { icon: "⚡", title: "Native emitter", desc: "Tighter code on every arch", target: "native" }
+  - { icon: "📡", title: "Counter / Encoder", desc: "Hardware pulse counting (esp32)", target: "counter" }
+
+stats:
+  - { value: 46, label: "Contributors" }
+  - { value: 13, label: "Timezones" }
+  - { value: 10, label: "New Boards" }
+
+mpy_banner:
+  headline: "Float and language demos on this page run real MicroPython in your browser."
+  body: "MicroPython is compiled to WebAssembly via PyScript and executes live as the page loads."
+
+toc:
+  - { id: "i2ctarget",   label: "machine.I2CTarget" }
+  - { id: "floats",      label: "Float Accuracy" }
+  - { id: "native",      label: "Native Emitter" }
+  - { id: "counter",     label: "Counter / Encoder" }
+  - { id: "language",    label: "Language Tweaks" }
+  - { id: "n6c2",        label: "STM32N6 + ESP32-C2" }
+  - { id: "highlights",  label: "Highlights" }
+
+boards:
+  summary: "10 new board definitions across 4 ports."
+  groups:
+    - port: "esp32"
+      boards: ["GARATRONIC_PYBSTICK26_ESP32C3", "SPARKFUN_IOT_REDBOARD_ESP32"]
+    - port: "samd"
+      boards: ["SPARKFUN_REDBOARD_TURBO", "SPARKFUN_SAMD21_DEV_BREAKOUT"]
+    - port: "stm32"
+      boards: ["NUCLEO_N657X0", "OPENMV_N6"]
+    - port: "zephyr"
+      boards: ["beagleplay_cc1352p7", "nrf5340dk", "nrf9151dk", "rpi_pico"]
+
+numbers:
+  summary: "v1.26 in numbers — esp32 grew most, driven by ESP-IDF v5.4.2."
+  cards:
+    - { value: 46, label: "Contributors" }
+    - { value: 13, label: "Timezones" }
+    - { value: 10, label: "New Boards" }
+  code_size:
+    title: "Code size delta vs v1.25 (text section)"
+    rows:
+      - { port: "esp32",      delta_kb: 19,  bar_pct: 100, tooltip: "+1.12% — IDF 5.4.2 + I2CTarget" }
+      - { port: "stm32",      delta_kb: 4,   bar_pct: 21,  tooltip: "+0.97% — I2CTarget, float accuracy, native emitter" }
+      - { port: "esp8266",    delta_kb: 3,   bar_pct: 18,  tooltip: "+0.50% — LX3 opcodes, LittleFS v2.11" }
+      - { port: "samd",       delta_kb: 3,   bar_pct: 17,  tooltip: "+1.23% — I2CTarget, float accuracy" }
+      - { port: "mimxrt",     delta_kb: 4,   bar_pct: 19,  tooltip: "+0.97% — I2CTarget, float accuracy" }
+      - { port: "rp2",        delta_kb: 1,   bar_pct: 5,   tooltip: "+0.25% — compressed error messages saved 3kB" }
+      - { port: "unix",       delta_kb: 0,   bar_pct: 2,   tooltip: "-0.05% — bss reduction, DTLS additions" }
+      - { port: "bare-arm",   delta_kb: -0.1,bar_pct: 1,   tooltip: "-0.17% — int var-arg handling" }
+  contributors: |
+    Alessandro Gatti, Andrea Giammarchi, Andrew Leech, Angus Gratton, Anson Mansfield,
+    Anton Blanchard, Ayush Singh, Chris Webb, Christian Lang, Damien George,
+    Daniel Campora, Daniël van de Giessen, David Schneider, David Yang, Detlev Zundel,
+    Dryw Wade, dubiousjim, Elvis Pfutzenreuter, ennyKey, Garatronic, Herwin Grobben,
+    iabdalkader, IhorNehrutsa, Jeff Epler, Jim Mussared, Jonathan Hogg, Jos Verlinde,
+    Koudai Aono, Malcolm McKellips, Matt Trentini, Maureen Helm, Meir Armon,
+    Patrick Joy, Peter Harper, Phil Howard, purewack, Rick Sorensen, robert-hh, root,
+    SiZiOUS, stijn, TianShuang Ke, Vdragon, Yanfeng Liu, Yoctopuce dev, Yuuki NAGAO.
+---
+```
+
+(Front-matter aliases: numbers + stats overlap — keep one; stats ribbon is at top of page,
+numbers section is at bottom with chart. Likely drop the duplicate `numbers.cards` and
+just reference the same block, or keep both with different framings.)
+
+---
+
+## Section 1 — `#i2ctarget` (Tier A — bespoke)
+
+**Heading**: "machine.I2CTarget — Your MCU answers, not just asks"
+**Badge**: NEW
+**Description**: One paragraph framing the inversion of the usual relationship: an
+MCU running MicroPython that *responds* to I2C transactions instead of initiating them.
+Available on **alif, esp32, mimxrt, rp2, samd, stm32, zephyr**.
+
+### Demo concept
+
+Two-MCU SVG diagram on a horizontal I2C bus.
+- Left MCU labelled "Controller" (running CPython on a host, hypothetically).
+- Right MCU labelled "Target — your MicroPython board".
+- Below the target: a `bytearray(16)` rendered as a 16-cell grid, each cell labelled by index.
+- Controls:
+  - "Address (hex)" input (default `0x10`).
+  - "Write" button: pops up "Write byte 0x42 to register 0x05?" and animates a packet flying
+    along the bus from controller to target; the target's `bytearray[5]` cell flashes and
+    updates to `0x42`.
+  - "Read" button: animates a packet flying back, output area shows `b'\x42'`.
+- A "Toggle: Buffer Mode / IRQ Mode" switch at the top.
+  - In **Buffer Mode**, the bytearray + `mem_offset=` API is shown.
+  - In **IRQ Mode**, an event log appears showing `IRQ_WRITE_REQ`, `IRQ_READ_REQ`, etc., and
+    a small Python snippet showing how a callback is registered.
+
+### Code panel (live, syntax-highlighted, copy button)
+
+```python
+from machine import I2C, I2CTarget, Pin
+
+# Buffer mode — register/memory device backed by a bytearray
+buf = bytearray(16)
+target = I2CTarget(0, scl=Pin(1), sda=Pin(0), addr=0x10, mem=buf)
+
+# Controller (on another board / host)
+i2c = I2C(0, scl=Pin(3), sda=Pin(2))
+i2c.writeto_mem(0x10, 0x05, b'\x42')   # buf[5] becomes 0x42
+print(i2c.readfrom_mem(0x10, 0x05, 1)) # b'\x42'
+```
+
+### Port matrix
+
+`port-matrix` component, with `alif`, `esp32`, `mimxrt`, `rp2`, `samd`, `stm32`, `zephyr`
+each marked `new-in-release`. Other `machine.*`-supporting ports shown in grey for context.
+
+### Bespoke CSS expected
+
+`.i2c-bus-svg`, `.i2c-bytearray-grid`, `.i2c-bytearray-cell`, `.i2c-controls`, `.i2c-irq-log`.
+~80 lines. Pattern: bus is a fixed-height SVG; bytearray grid is a CSS grid.
+
+### Bespoke JS expected
+
+Animation primitives copied from v1.28's CAN demo (`requestAnimationFrame` packet flyer,
+log append). One mode switch, two action buttons. ~120 lines. **Listens for `themechange`**
+to redraw SVG strokes.
+
+### Open question
+
+Should the "controller" side be drawn as another MicroPython board, or as a generic
+"host" to keep focus on the target? — leaning generic host so the asymmetry is obvious.
+
+---
+
+## Section 2 — `#floats` (Tier B — PyScript live, with Tier-A infographic)
+
+**Heading**: "Float Accuracy — repr round-trips for real"
+**Badge**: IMPROVED
+**Description**: Short explanation of repr-reversibility in user-visible terms (not
+"OBJ_REPR_C heuristic"). Frame: "before v1.26, ~28% of single-precision floats lost
+information when printed and re-parsed. Now it's 98.5%."
+
+### Tier-A infographic (no live code)
+
+Two horizontal bars side by side:
+- "v1.25 and earlier: ████░░░░░░░░░░░ 28% (single) / 38% (double)"
+- "v1.26+:           ███████████████ 98.5% (single) / 99.8% (double)"
+
+Pure CSS bars with tabular-num counters animating from 0% → target on scroll-in.
+Reuses `.numbers-grid` styling but with horizontal bars.
+
+### Tier-B PyScript playground
+
+Editable code panel with this default content:
+
+```python
+# Try a tricky float — this is real MicroPython running in your browser.
+x = 0.1 + 0.2
+print(repr(x))                  # 0.30000000000000004 (CPython-equivalent)
+print(float(repr(x)) == x)      # True — repr round-trips
+
+# Some classic offenders:
+for v in [1/3, 1e-300, 2**-1074, 1.5e308]:
+    s = repr(v)
+    print(f"{v!r:30}  -> {s!r:30}  round-trips: {float(s) == v}")
+```
+
+Output panel below shows the live results.
+
+### Tier-A "before" pane (static)
+
+Beside the playground, a non-editable code panel labelled **"What v1.25 would have shown"**
+with hand-crafted output that uses MicroPython's pre-v1.26 truncation rules — clearly marked
+as a historical reproduction. ~6–8 lines.
+
+### Bespoke CSS expected
+
+`.float-bars`, `.float-bar-row`, `.float-comparison-grid` (2-col grid for live vs historical).
+~40 lines.
+
+### Bespoke JS expected
+
+Bar-fill animation triggered on scroll-in (IntersectionObserver, ~30 lines).
+PyScript wiring is shared (lives in the layout's `pyscript_block`).
+
+### Open question
+
+How explicit do we get about "this would have printed differently in v1.25"? Risk: someone
+copy-pastes our hand-crafted "before" output thinking it's authoritative. Mitigation: tag it
+with a clear "historical reconstruction" label and a tooltip linking to the upstream PR/commit.
+
+---
+
+## Section 3 — `#native` (Tier C — port matrix + size chart)
+
+**Heading**: "Native & Viper Emitter — every architecture got a tune-up"
+**Badge**: IMPROVED
+**Description**: One paragraph: more compact loads/stores on **ARM, Thumb, Xtensa, RISC-V 32,
+x86, x64**. Thumb v1 (RP2040) gets long jumps >12 bits, allowing larger Python functions to
+compile native. Xtensa inline assembler now implements most of LX3 (addx2, subx2, ssl, ssr…).
+
+### Demo concept — Tier C only
+
+Static info panels:
+1. **Architecture grid** — 6 chips (ARM, Thumb, Thumb-v1, Xtensa, RV32, x86, x64), each
+   showing what changed (mini-list of 2–3 bullets). Reuses `.port-matrix` styling with
+   architecture names instead of port names.
+2. **Long-jump callout**: a short `.callout` block with the RP2040-specific implication —
+   "Functions over a few hundred lines of Python can now compile to `@micropython.native`
+   on RP2040."
+3. **Code-size impact** mini-chart: just the relevant rows from the by-the-numbers chart,
+   filtered to architectures where the emitter actually got bigger/smaller. Probably skip if
+   the dedicated by-the-numbers section already shows it.
+
+### Why Tier C, not Tier B
+
+In principle this *could* be Tier B (write a native-emitted function in PyScript and time it).
+But: (i) `@micropython.native` exists in the webassembly variant only as the WASM-targeted
+emitter, so timing wouldn't reflect the LX3/Thumb-v1 wins anyway; (ii) microbenchmarks in a
+browser are noisy and would mislead. Skip the live demo.
+
+### Bespoke CSS expected
+
+None — uses `.port-matrix`, `.callout`, `.highlight-card` from shared CSS.
+
+### Bespoke JS expected
+
+None.
+
+---
+
+## Section 4 — `#counter` (Tier A — bespoke, esp32-only)
+
+**Heading**: "machine.Counter & machine.Encoder — Hardware pulse counting"
+**Badge**: NEW
+**Description**: New on **esp32** only (via `esp32.PCNT`). `Counter` counts edges; `Encoder`
+decodes quadrature for motor rotation. Important caveat: API lives under `machine.*` but is
+currently only implemented on esp32.
+
+### Demo concept
+
+Interactive virtual quadrature encoder.
+- Left: an SVG circular dial with a tick mark, draggable by mouse/touch.
+- Centre: as user drags, two square-wave traces (channel A, channel B) are drawn below,
+  90° out of phase. Coloured boxes flash as edges occur.
+- Right: a live `count: 0` display that increments/decrements based on rotation direction.
+- A "Direction: ↻" indicator that flips based on whether B leads A or A leads B.
+- Mode toggle at top: "Counter (single channel)" / "Encoder (quadrature)" — collapses
+  channel B trace away when in single-channel mode.
+
+### Code panel
+
+```python
+from machine import Pin, Encoder
+
+enc = Encoder(0, phase_a=Pin(4), phase_b=Pin(5))
+print(enc.value())   # rotation count, sign indicates direction
+```
+
+### Caveat callout
+
+`.callout` block: **"esp32 only in v1.26"** — API lives under `machine.*` but other ports
+hadn't picked it up at this release. Useful expectation-setting, since the v1.28 release later
+adds standardised cross-port `machine.PWM`/`CAN`.
+
+### Bespoke CSS expected
+
+`.encoder-dial`, `.encoder-traces`, `.encoder-controls`. ~50 lines.
+
+### Bespoke JS expected
+
+Drag handler on dial, draws two-channel waveform on canvas. Tracks angle and decodes
+quadrature in JS (mirroring what PCNT does in hardware). Listens for `themechange`. ~150 lines.
+
+---
+
+## Section 5 — `#language` (Tier B — combined PyScript playground)
+
+**Heading**: "Python language tweaks"
+**Badge**: NEW
+**Description**: Several small additions, easier to digest as one playground with an
+example-picker than five tiny demos.
+
+### Demo concept
+
+One PyScript editor with a dropdown of pre-baked examples:
+
+1. **`__all__` in star imports** — small module + `from x import *` semantics.
+2. **PEP 487 `__set_name__`** — descriptor whose name is captured at class body time.
+3. **`str.format` digit grouping** — `f"{0xdeadbeef:_x}"` and friends.
+4. **`array` from any iterable** — `array('i', range(5))` now works.
+5. **Slice on stack** — show `bytearray_obj[a:b] = c` working under
+   `micropython.heap_lock()` (gc lock). Educational; demonstrates the v1.26 VM win.
+
+Selecting an item swaps the editor contents to the matching example. Run button executes.
+
+### PyScript script (shared, lives in layout's `pyscript_block` for v1.26)
+
+Standard PyScript wiring used by the v1.28 page, lifted as-is, with `mpy-code-editor` /
+`mpy-output` element pairs.
+
+### Bespoke CSS expected
+
+`.example-picker` (a styled `<select>`). ~20 lines.
+
+### Bespoke JS expected
+
+`<select>` change handler swaps editor contents from a JS-side dictionary of examples.
+~40 lines. **Reusable pattern** — should be extracted to shared JS once we use it on a
+second page.
+
+### Open question
+
+Slice-on-stack under `heap_lock` is the cleverest one — but `heap_lock`/`heap_unlock` exist
+on `micropython` module at FULL_FEATURES level. Worth verifying via the PyScript playground
+once the page is live.
+
+---
+
+## Section 6 — `#n6c2` (Tier C — spec cards)
+
+**Heading**: "STM32N6 & ESP32-C2 — two new MCUs"
+**Badge**: NEW PORT MEMBER
+**Description**: Two side-by-side spec cards.
+
+- **STM32N6**: 800 MHz, ML accelerators, USB, XSPI memory-mapped flash, deepsleep. Boards:
+  `NUCLEO_N657X0`, `OPENMV_N6`.
+- **ESP32-C2 (ESP8684)**: low-cost RISC-V, WiFi + BLE, GPIO, I2C, ADC, PWM, timers.
+
+### Demo concept
+
+Two `.highlight-card`-style panels with:
+- MCU name (header)
+- Key spec strip (clock, RAM, ML accel y/n, radios)
+- Supported peripheral list
+- Boards-using-it tag list
+- "Released in v1.26" badge
+
+The STM32N6 panel could include a small ML-accelerator icon or a callout linking to OpenMV's
+N6 board for context, since OpenMV is the target use case.
+
+### Bespoke CSS expected
+
+`.mcu-spec-card`, `.mcu-spec-strip`. ~30 lines. Could be promoted to shared CSS if every
+release page uses it (likely yes — spec cards for new MCUs is a recurring pattern).
+
+### Bespoke JS expected
+
+None.
+
+---
+
+## Section 7 — `#highlights` (Tier C — highlights grid)
+
+Reuses the shared `.highlights-grid` / `.highlight-card` components. Brief cards for items
+that don't warrant a full section:
+
+- **DTLS server support** (mbedTLS HelloVerify + Anti Replay)
+- **lwIP UDP queue** — multiple incoming UDP packets queued
+- **`framebuf` ROM blits** — store fonts in ROM
+- **`time` module date range standardised** — 1970–2099 across all platforms
+- **Compressed error messages on rp2** (-3 kB)
+- **mpremote `fs tree`** + better `df`
+- **Standard time-function range** across platforms
+- **`sys.implementation._thread`** — tells you the threading model (GIL vs unsafe)
+- **nrf `enable_irq()` signature change** — *breaking* on nrf only; lead with the warning
+- **Zephyr v4.0.0** + PWM/UART/SPI/I2C improvements
+- **Webassembly FFI**: `JsProxy` equality, `has`/`get` proxying, self-binding
+
+10–12 cards. Each has icon, h3, 1–2 sentence description, optional port-tag chips.
+
+---
+
+## Section 8 — Sections that already come from the layout
+
+These come "for free" via shared includes — **no per-page work**:
+
+- Hero (front-matter `hero:`)
+- Summary cards (front-matter `summary_cards:`)
+- Stats ribbon (front-matter `stats:`)
+- mpy-banner (front-matter `mpy_banner:`)
+- New Boards grid (front-matter `boards:`)
+- By the Numbers + code-size chart (front-matter `numbers:`)
+- Footer
+
+---
+
+## Estimated effort
+
+Layout + content scaffolding: ~half day (front-matter + Tier C sections).
+
+Bespoke demos:
+- I2CTarget (Tier A): ~1 day. SVG bus + bytearray grid + 2 modes is the most ambitious.
+- Float accuracy (Tier B + infographic): ~half day.
+- Counter/Encoder (Tier A): ~half day. Quadrature canvas is well-bounded.
+- Language tweaks (Tier B): ~2 hours.
+
+**Total: ~2.5 days** for v1.26 once shared infra is in place.
+
+Compared to v1.28's ~3 days from scratch, this is the win we're chasing — shared infra
+removes the ~half-day of boilerplate per release.
+
+---
+
+## What this build will prove (or break)
+
+1. The shared CSS / layout / includes work end-to-end.
+2. The `themechange` event pattern works for bespoke canvas demos.
+3. The PyScript playground pattern can be reused outside v1.28.
+4. The front-matter schema is rich enough for real content (or what gaps it has).
+5. Whether `marshal`/`heap_lock`/etc. behave in the pyscript variant as we predicted from
+   the static config inspection.
+
+If anything in 1–4 cracks, we fix it in the shared infra rather than working around it
+per-page. That's the whole point of building v1.26 first.
+
+---
+
+## Open questions to resolve before code
+
+1. Does the v1.26 page need a **"jump to v1.27/v1.28"** nav widget at the top, or do we
+   defer until the `/releases/` index exists?
+2. Hero badge wording for older releases — "Past Release" feels awkward. Alternatives:
+   "Released August 2025", or just a date stamp without a badge.
+3. Code-size chart: keep both the stats ribbon (top) and the numbers section (bottom), or
+   consolidate? They overlap.
+4. How aggressive should the Tier-B "before-and-after" framing be on the float section?
+   Showing fake historical output has accuracy risks even with disclaimers.

--- a/micropython-v1.24/index.html
+++ b/micropython-v1.24/index.html
@@ -1,0 +1,622 @@
+---
+layout: release-notes
+title: MicroPython v1.24.0 Release Notes
+version: v1.24.0
+pyscript: true
+page_css: /micropython-v1.24/v1.24.css
+page_js: /micropython-v1.24/v1.24.js
+
+hero:
+  version: "v1.24"
+  tagline: "RP2350 lands, RISC-V grows up, ESP32-C6 arrives, and TinyUSB CDC code is unified across five ports."
+  date: "October 26, 2024"
+
+summary_cards:
+  - { icon: "&#127814;",  title: "RP2350",      desc: "ARM and RISC-V on the same chip", target: "newmcus" }
+  - { icon: "&#9889;",    title: "ESP32-C6",    desc: "WiFi 6 + 802.15.4 RISC-V SoC",    target: "newmcus" }
+  - { icon: "&#128257;",  title: "RingIO",      desc: "Thread-safe ring buffer",         target: "ringio" }
+  - { icon: "&#127760;",  title: "ipconfig()",  desc: "IPv4 + IPv6 network config",      target: "ipconfig" }
+
+stats:
+  - { value: 58, label: "Contributors" }
+  - { value: 15, label: "Timezones" }
+  - { value: 10, label: "New Boards" }
+
+mpy_banner:
+  headline: "RingIO and language demos on this page run real MicroPython in your browser."
+  body: "MicroPython is compiled to WebAssembly via PyScript and executes live as the page loads &mdash; no server required. v1.24 is the release where the webassembly port also gained top-level await of asyncio Tasks."
+
+toc:
+  - { id: "newmcus",  label: "RP2350 + ESP32-C6" }
+  - { id: "rv32",     label: "RISC-V Native Emitter" }
+  - { id: "ringio",   label: "micropython.RingIO" }
+  - { id: "ipconfig", label: "network.ipconfig" }
+  - { id: "tinyusb",  label: "TinyUSB + UART IRQs" }
+  - { id: "language", label: "Language Tweaks" }
+  - { id: "highlights", label: "Highlights" }
+
+boards:
+  summary: "10 new board definitions, weighted heavily toward ESP32-C6 and RP2350-class boards."
+  groups:
+    - port: "esp32"
+      boards:
+        - "ESP32_GENERIC_C6"
+        - "M5STACK_ATOMS3_LITE"
+        - "M5STACK_NANOC6"
+        - "OLIMEX_ESP32_EVB"
+        - "UM_FEATHERS3NEO"
+        - "UM_OMGS3"
+        - "UM_RGBTOUCH_MINI"
+        - "UM_TINYC6"
+    - port: "rp2"
+      boards: ["RPI_PICO2"]
+    - port: "stm32"
+      boards: ["ARDUINO_OPTA"]
+
+numbers:
+  summary: "v1.24 in numbers. esp32 firmware actually shrank by 53 kB after the ESP-IDF cleanup &mdash; the only port-shrink across the five recent releases."
+  cards:
+    - { value: 58, label: "Contributors" }
+    - { value: 15, label: "Timezones" }
+    - { value: 10, label: "New Boards" }
+  code_size:
+    title: "Code size delta vs v1.23 (.text section, bytes)"
+    rows:
+      - { port: "unix x64",   delta_bytes: 8994,   bar_pct: 17,  tooltip: "+1.10% &mdash; GCM and ECDHE-RSA mbedTLS config" }
+      - { port: "rp2",        delta_bytes: 3592,   bar_pct: 7,   tooltip: "+1.07% &mdash; RP2350 + RingIO + UART.irq" }
+      - { port: "esp8266",    delta_bytes: 2968,   bar_pct: 6,   tooltip: "+0.43% &mdash; ipconfig + RingIO" }
+      - { port: "samd",       delta_bytes: 2244,   bar_pct: 4,   tooltip: "+0.85% &mdash; RingIO + UART.irq" }
+      - { port: "mimxrt",     delta_bytes: 1864,   bar_pct: 4,   tooltip: "+0.51% &mdash; RingIO + UART.irq" }
+      - { port: "renesas-ra", delta_bytes: 1536,   bar_pct: 3,   tooltip: "+0.25% &mdash; RingIO + UART.irq" }
+      - { port: "nrf",        delta_bytes: 1460,   bar_pct: 3,   tooltip: "+0.78% &mdash; RingIO + UART.irq" }
+      - { port: "cc3200",     delta_bytes: 1152,   bar_pct: 2,   tooltip: "+0.62% &mdash; ipconfig + WLAN.ipconfig" }
+      - { port: "stm32",      delta_bytes: 1028,   bar_pct: 2,   tooltip: "+0.26% &mdash; new RingIO class" }
+      - { port: "minimal x86",delta_bytes: 185,    bar_pct: 1,   tooltip: "+0.10% &mdash; int.to_bytes() buffer-size fixes" }
+      - { port: "bare-arm",   delta_bytes: 116,    bar_pct: 1,   tooltip: "+0.20% &mdash; int.to_bytes() buffer-size fixes" }
+      - { port: "esp32",      delta_bytes: -53617, bar_pct: 100, tooltip: "-3.10% &mdash; ESP-IDF cleanup (v5.0.5 -> v5.2.2)" }
+  contributors: |
+    Adrian Higgins, Alessandro Gatti, Alexandre Iooss, Amirreza Hamzavi,
+    Andrea Milazzo, Andrew Leech, Angus Gratton, Ayush Singh, cajt,
+    Christian Walther, Corran Webster, Damien George, Dan Halbert, danicampora,
+    David Lechner, dmfaria, Dryw Wade, Elvis Pf&uuml;tzenreuter, Felix D&ouml;rre,
+    George Hopkins, Glenn Moloney, iabdalkader, IhorNehrutsa, Jared Hancock,
+    Jason Kridner, Jim Mussared, Jon Foster, Jos Verlinde, Junwha, Laurens Valk,
+    Lennart, Leo Chung, Matt Trentini, Matthias Blankertz, Maureen Helm,
+    Michael Sawyer, Michael Vornovitsky, nspsck, Owen, Paul Grayson, Peter Harper,
+    Peter Z&uuml;ger, Phil Howard, Plaque FCC, Rick Sorensen, robert-hh,
+    Seon Rozenblum, shiggy, stijn, Sylvain Zimmer, Takeo Takahashi,
+    Terence Stenvold, tharuka, Tim Weber, timdechant, Volodymyr Shymanskyy,
+    Yoctopuce, ZodiusInfuser.
+
+pyscript_block: |
+  from pyscript import document, when
+  import sys
+
+  def run_editor(code_id, out_id):
+      code = document.querySelector("#" + code_id).value
+      out_el = document.querySelector("#" + out_id)
+      out_el.classList.remove("has-error")
+      lines = []
+      def _print(*args, sep=" ", end="\n"):
+          lines.append(sep.join(str(a) for a in args) + end)
+      try:
+          exec(code, {"print": _print})
+          output = "".join(lines) or "(no output)"
+      except Exception as e:
+          output = type(e).__name__ + ": " + str(e)
+          out_el.classList.add("has-error")
+      out_el.innerText = output
+
+  @when("click", "#ringio-run")
+  def _r_ringio(ev):
+      run_editor("ringio-editor", "ringio-output")
+
+  @when("click", "#lang-run")
+  def _r_lang(ev):
+      run_editor("lang-editor", "lang-output")
+
+  for s in document.querySelectorAll(".mpy-status"):
+      s.innerText = f"MicroPython {sys.version} ready"
+---
+
+<!-- ===== SECTION: NEW MCUs (RP2350 + ESP32-C6) ===== -->
+<section class="section" id="newmcus">
+  <div class="section-header">
+    <span class="section-badge new">Two new MCUs</span>
+    <h2>RP2350 &amp; ESP32-C6</h2>
+    <p class="section-desc">
+      v1.24 brings up two important new chips. <strong>RP2350</strong> is the headline:
+      Raspberry Pi's successor to the RP2040, with both ARM and RISC-V cores
+      <em>on the same die</em>, in 30- and 48-pin variants. <strong>ESP32-C6</strong>
+      is Espressif's RISC-V chip with WiFi 6 and 802.15.4 (Thread / Zigbee).
+    </p>
+  </div>
+
+  <div class="demo-container">
+    <div class="demo-label">Interactive Demo &mdash; RP2350: ARM or RISC-V?</div>
+
+    <div class="rp-arch-toggle">
+      <button class="active" data-arch="arm">Cortex-M33 (ARM)</button>
+      <button data-arch="riscv">Hazard3 (RISC-V)</button>
+    </div>
+
+    <div class="rp-stage">
+      <svg class="rp-svg" viewBox="0 0 600 240" preserveAspectRatio="xMidYMid meet">
+        <!-- RP2350 chip -->
+        <rect x="80" y="40" width="440" height="160" class="rp-chip"/>
+        <text x="300" y="80" class="rp-chip-label">RP2350</text>
+        <text x="300" y="100" class="rp-chip-sub">Raspberry Pi&apos;s 2024 MCU</text>
+
+        <!-- Two cores -->
+        <rect x="160" y="120" width="120" height="60" class="rp-core" id="rp-core-0"/>
+        <text x="220" y="148" class="rp-core-label" id="rp-core-0-label">Cortex-M33</text>
+        <text x="220" y="166" class="rp-core-sub" id="rp-core-0-sub">core 0</text>
+
+        <rect x="320" y="120" width="120" height="60" class="rp-core" id="rp-core-1"/>
+        <text x="380" y="148" class="rp-core-label" id="rp-core-1-label">Cortex-M33</text>
+        <text x="380" y="166" class="rp-core-sub" id="rp-core-1-sub">core 1</text>
+
+        <!-- Architecture indicator badge -->
+        <rect x="446" y="48" width="62" height="22" class="rp-arch-badge" id="rp-arch-badge"/>
+        <text x="477" y="63" class="rp-arch-badge-label" id="rp-arch-badge-label">ARM</text>
+      </svg>
+    </div>
+
+    <div class="rp-info">
+      <div class="rp-info-card">
+        <div class="rp-info-label">Native emitter</div>
+        <div class="rp-info-value" id="rp-info-emitter"><code>@micropython.native</code> &rarr; Thumb v1</div>
+      </div>
+      <div class="rp-info-card">
+        <div class="rp-info-label">Inline assembler</div>
+        <div class="rp-info-value" id="rp-info-asm"><code>@micropython.asm_thumb</code></div>
+      </div>
+      <div class="rp-info-card">
+        <div class="rp-info-label">Board</div>
+        <div class="rp-info-value" id="rp-info-board">RPI_PICO2 (default ARM build)</div>
+      </div>
+    </div>
+
+    <p class="rp-note">
+      The RP2350 ships with both an ARM Cortex-M33 and a RISC-V Hazard3 core pair on
+      the same die. The bootrom selects which cores to wake at startup, controlled by
+      the firmware build. v1.24 lands MicroPython support for both modes.
+    </p>
+  </div>
+
+  <div class="mcu-spec-cards" style="margin-top:24px;">
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>ESP32-C6</h3>
+        <span class="badge active">RISC-V + WiFi 6</span>
+      </div>
+      <div class="mcu-spec-strip">
+        <div><span class="mcu-spec-num">RV32</span> + WiFi 6</div>
+        <div><span class="mcu-spec-num">802.15.4</span> radio</div>
+        <div><span class="mcu-spec-num">native</span> emitter</div>
+      </div>
+      <p class="mcu-spec-desc">
+        Espressif's RISC-V SoC with WiFi 6 and 802.15.4 (Thread / Zigbee). v1.24
+        enables the <strong>RV32IMC native emitter</strong> on both C3 and C6, so
+        <code>@micropython.native</code>-decorated functions compile to tight RISC-V
+        machine code on these chips.
+      </p>
+      <div class="mcu-spec-boards">
+        <span class="board-chip">ESP32_GENERIC_C6</span>
+        <span class="board-chip">M5STACK_NANOC6</span>
+        <span class="board-chip">UM_TINYC6</span>
+      </div>
+    </div>
+
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>RP2350 details</h3>
+        <span class="badge active">pico-sdk v2.0.0</span>
+      </div>
+      <ul class="rp-bullets">
+        <li><strong>30- and 48-pin variants</strong> &mdash; both supported.</li>
+        <li><strong>IPv6 enabled by default</strong> on the rp2 port.</li>
+        <li><strong>USB stays active during <code>machine.lightsleep()</code></strong>.</li>
+        <li><strong>Optional <code>network.PPP</code></strong> &mdash; lwIP-based, opt-in.</li>
+        <li>RP2040 still fully supported &mdash; same firmware family, just a new board.</li>
+      </ul>
+      <div class="mcu-spec-boards" style="margin-top:12px;">
+        <span class="board-chip">RPI_PICO2</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== SECTION: RV32 emitter ===== -->
+<section class="section" id="rv32">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>RISC-V 32-bit Native Emitter</h2>
+    <p class="section-desc">
+      MicroPython has had native code generation for ARM, Thumb, Xtensa and x86/x64
+      for years. v1.24 adds <strong>RV32IMC</strong>: <code>@micropython.native</code>
+      now compiles directly to RISC-V machine code, no interpretation. Decorated
+      functions land in <code>.mpy</code> files (and can be frozen) just like other
+      architectures. v1.24 also adds RISC-V NLR and GC register-scanning, plus
+      semihosting for testing under <code>qemu</code>.
+    </p>
+  </div>
+
+  <h3 style="font-size:18px; margin-top:8px; margin-bottom:12px;">RV32 native emitter port support</h3>
+  <div class="port-matrix">
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> esp32 (C3)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> esp32 (C6)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> rp2 (RP2350 / RV)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> qemu (rv32)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> unix (rv32)</div>
+  </div>
+
+  <div class="code-block" style="margin-top:24px;">
+    <div class="code-header">
+      <span>main.py &mdash; works identically across architectures</span>
+      <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+    </div>
+<pre><span class="kw">import</span> micropython
+
+<span class="kw">@micropython.native</span>
+<span class="kw">def</span> <span class="fn">crc16</span>(data, init=<span class="num">0xffff</span>):
+    crc = init
+    <span class="kw">for</span> b <span class="kw">in</span> data:
+        crc ^= b
+        <span class="kw">for</span> _ <span class="kw">in</span> <span class="bi">range</span>(<span class="num">8</span>):
+            crc = (crc &gt;&gt; <span class="num">1</span>) ^ <span class="num">0xa001</span> <span class="kw">if</span> crc &amp; <span class="num">1</span> <span class="kw">else</span> crc &gt;&gt; <span class="num">1</span>
+    <span class="kw">return</span> crc &amp; <span class="num">0xffff</span>
+
+<span class="cmt"># On RP2350 (RV mode) and ESP32-C3/C6, this compiles to RV32IMC.</span>
+<span class="cmt"># On RP2040 / RP2350 (ARM mode), it compiles to Thumb.</span>
+<span class="cmt"># On Xtensa esp32 / S2 / S3, Xtensa LX6 / LX7.</span></pre>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">qemu becomes a first-class test target</div>
+    The <code>qemu-arm</code> port has been renamed to just <code>qemu</code> and now
+    supports both ARM and RISC-V. It runs tests via a pty serial port &mdash;
+    emulating bare-metal targets &mdash; which makes architecture-portable testing
+    much more practical.
+  </div>
+</section>
+
+<!-- ===== SECTION: RingIO ===== -->
+<section class="section" id="ringio">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2><code>micropython.RingIO</code> &mdash; Thread-Safe Ring Buffer</h2>
+    <p class="section-desc">
+      A new built-in class providing an efficient, byte-oriented ring buffer with a
+      stream interface. <strong>Thread-safe</strong>, fixed allocation, no GC pressure
+      at runtime &mdash; ideal for producer/consumer patterns between an ISR and the
+      main loop, between cores, or between the REPL and a background task. Try it
+      below in your browser.
+    </p>
+  </div>
+
+  <div class="demo-container live-playground">
+    <div class="demo-label">
+      Live demo
+      <span class="pyscript-tag">PyScript</span>
+    </div>
+    <p class="playground-intro">
+      <code>RingIO</code> is a stream &mdash; you can <code>read()</code>,
+      <code>write()</code>, and <code>readinto()</code> just like a file. The
+      buffer is fixed-size and FIFO; reads block (in a real port) when empty.
+    </p>
+    <textarea class="mpy-code-editor" id="ringio-editor" spellcheck="false">from micropython import RingIO
+
+# Allocate a 16-byte ring buffer
+ring = RingIO(16)
+
+# Producer side: write some bytes
+ring.write(b"hello")
+print("after write 'hello':       any() =", ring.any())
+
+ring.write(b" world!")
+print("after write ' world!':     any() =", ring.any())
+
+# Consumer side: read them back in chunks
+print("read(5):", ring.read(5))
+print("read(7):", ring.read(7))
+print("after both reads:          any() =", ring.any())
+
+# Wraparound -- write past the end of the buffer
+ring.write(b"this exceeds the buffer size")
+print("after over-sized write:    any() =", ring.any(), "  (capped at buffer size)")
+print("read all:", ring.read())
+</textarea>
+    <div class="mpy-btn-row">
+      <button class="mpy-run-btn" id="ringio-run">Run &#9654;</button>
+      <span class="mpy-status">Loading MicroPython&hellip;</span>
+    </div>
+    <div class="mpy-output" id="ringio-output"></div>
+    <p class="playground-note">
+      In a real-world MicroPython program, <code>RingIO</code> shines in scenarios
+      where one side runs in an interrupt handler (a hard IRQ, even). The fixed
+      allocation means no heap pressure, and the implementation is reentrant on
+      every supported port.
+    </p>
+  </div>
+</section>
+
+<!-- ===== SECTION: ipconfig ===== -->
+<section class="section" id="ipconfig">
+  <div class="section-header">
+    <span class="section-badge new">New API</span>
+    <h2><code>network.ipconfig()</code> &mdash; IPv6-aware Network Config</h2>
+    <p class="section-desc">
+      v1.24 introduces <code>network.ipconfig()</code> at module level and
+      <code>nic.ipconfig()</code> on individual interfaces. The new API supports
+      <strong>IPv4 and IPv6</strong> with much more control than the legacy
+      <code>nic.ifconfig()</code>. The old API still works (backwards compatibility),
+      but new code should prefer <code>ipconfig()</code>.
+    </p>
+  </div>
+
+  <div class="ip-side-by-side">
+    <div class="ip-pane">
+      <div class="ip-pane-label">Legacy <code>ifconfig()</code> &mdash; IPv4 only</div>
+<pre class="ip-pre"><span class="kw">import</span> network
+
+nic = network.WLAN(network.STA_IF)
+nic.active(<span class="bi">True</span>)
+nic.connect(<span class="str">"ssid"</span>, <span class="str">"pw"</span>)
+
+<span class="cmt"># Tuple shape: (ip, mask, gw, dns)</span>
+nic.<span class="op">ifconfig</span>((
+    <span class="str">"192.168.1.50"</span>,
+    <span class="str">"255.255.255.0"</span>,
+    <span class="str">"192.168.1.1"</span>,
+    <span class="str">"8.8.8.8"</span>,
+))
+print(nic.ifconfig())</pre>
+    </div>
+    <div class="ip-pane">
+      <div class="ip-pane-label"><code>ipconfig()</code> &mdash; <strong>v1.24+</strong>, IPv4 + IPv6</div>
+<pre class="ip-pre"><span class="kw">import</span> network
+
+nic = network.WLAN(network.STA_IF)
+nic.active(<span class="bi">True</span>)
+nic.connect(<span class="str">"ssid"</span>, <span class="str">"pw"</span>)
+
+<span class="cmt"># Keyword args; pick what you need</span>
+nic.<span class="op">ipconfig</span>(
+    addr4=(<span class="str">"192.168.1.50"</span>, <span class="str">"255.255.255.0"</span>),
+    gw4=<span class="str">"192.168.1.1"</span>,
+    dhcp4=<span class="bi">False</span>,
+)
+network.ipconfig(dns=<span class="str">"2606:4700:4700::1111"</span>)  <span class="cmt"># IPv6 DNS</span>
+
+print(nic.ipconfig(<span class="str">"addr4"</span>))
+print(nic.ipconfig(<span class="str">"addr6"</span>))</pre>
+    </div>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">Plus: portable PPP</div>
+    A new <code>network.PPP</code> class based on lwIP is also available in v1.24.
+    Not enabled by default, but boards that already use bare-metal lwIP can opt in
+    &mdash; the rp2 port already exposes it as an option, and stm32 follows.
+  </div>
+</section>
+
+<!-- ===== SECTION: TinyUSB + UART IRQs ===== -->
+<section class="section" id="tinyusb">
+  <div class="section-header">
+    <span class="section-badge improved">Cross-port</span>
+    <h2>TinyUSB CDC unification &amp; portable UART IRQ API</h2>
+    <p class="section-desc">
+      Five ports that previously each had their own TinyUSB integration now share
+      common helper code for CDC serial. As a side effect, the REPL banner and
+      initial prompt are buffered until host connection &mdash; <strong>so the first
+      thing you see when you connect is the banner, not silence</strong>.
+    </p>
+    <p class="section-desc">
+      Most ports also gain a <strong>portable UART IRQ API</strong>. Register Python
+      callbacks for <code>IRQ_RX</code>, <code>IRQ_RXIDLE</code>,
+      <code>IRQ_TXIDLE</code> and <code>IRQ_BREAK</code> with consistent semantics
+      across the family.
+    </p>
+  </div>
+
+  <h3 style="font-size:16px; margin-top:8px; margin-bottom:12px;">Unified TinyUSB CDC</h3>
+  <div class="port-matrix">
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> esp32 (S2 / S3)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> mimxrt</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> renesas-ra</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> rp2</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> samd</div>
+  </div>
+
+  <h3 style="font-size:16px; margin-top:24px; margin-bottom:12px;">Portable <code>UART.irq()</code></h3>
+  <div class="port-matrix">
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> esp32</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> mimxrt</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> nrf</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> renesas-ra</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> rp2</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> samd</div>
+    <div class="port-chip"><span class="check">&#10003;</span> stm32 (had it already)</div>
+  </div>
+
+  <div class="code-block" style="margin-top:16px;">
+    <div class="code-header">
+      <span>main.py &mdash; works the same on every supported port</span>
+      <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+    </div>
+<pre><span class="kw">from</span> machine <span class="kw">import</span> UART
+
+uart = UART(<span class="num">0</span>, baudrate=<span class="num">115200</span>)
+
+<span class="kw">def</span> <span class="fn">on_rx</span>(u):
+    <span class="bi">print</span>(<span class="str">"got"</span>, u.read())
+
+uart.irq(handler=on_rx, trigger=UART.IRQ_RX | UART.IRQ_RXIDLE)</pre>
+  </div>
+</section>
+
+<!-- ===== SECTION: Language tweaks ===== -->
+<section class="section" id="language">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>Python language tweaks</h2>
+    <p class="section-desc">
+      Three core-language changes in v1.24, including a <strong>breaking change</strong>
+      to <code>sys.exit()</code>. Pick one from the dropdown to load the example,
+      then run it live.
+    </p>
+  </div>
+
+  <div class="demo-container live-playground">
+    <div class="demo-label">
+      Live demo
+      <span class="pyscript-tag">PyScript</span>
+    </div>
+
+    <div class="example-picker-row">
+      <label for="lang-picker">Example:</label>
+      <select id="lang-picker" class="example-picker">
+        <option value="fstring_concat">f-string concatenation</option>
+        <option value="raw_fstring">Raw f-strings</option>
+        <option value="sysexit">sys.exit() &mdash; breaking change</option>
+      </select>
+    </div>
+
+    <textarea class="mpy-code-editor" id="lang-editor" spellcheck="false"></textarea>
+    <div class="mpy-btn-row">
+      <button class="mpy-run-btn" id="lang-run">Run &#9654;</button>
+      <button class="mpy-clear-btn" id="lang-reset">Reset example</button>
+      <span class="mpy-status">Loading MicroPython&hellip;</span>
+    </div>
+    <div class="mpy-output" id="lang-output"></div>
+
+    <p class="playground-note" id="lang-note"></p>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">Webassembly: top-level await of Task and Event</div>
+    The webassembly port (which is what makes this page possible) gained an important
+    asyncio improvement in v1.24: you can now <code>await</code> a
+    <code>Task</code> or <code>Event</code> at module top level. This means a
+    <code>&lt;script type="mpy"&gt;</code> block can do
+    <code>result = await some_task()</code> directly, with no
+    <code>asyncio.run()</code> wrapping. PyScript also gained
+    <code>JsProxy</code> identity reuse, attribute lookup without existence checks,
+    and JS iterable proxying.
+  </div>
+</section>
+
+<!-- ===== SECTION: Highlights ===== -->
+<section class="section" id="highlights">
+  <div class="section-header">
+    <h2>Highlights</h2>
+    <p class="section-desc">Other notable improvements in v1.24.</p>
+  </div>
+
+  <div class="highlights-grid">
+    <div class="highlight-card">
+      <span class="hl-icon">&#127919;</span>
+      <h3>esp32 firmware shrank by 53 kB</h3>
+      <p>The IDF v5.0.5 -&gt; v5.2.2 update plus internal cleanup gives back over
+        50 kB of flash on every esp32 build (-3.10%). Big win for memory-constrained
+        boards.</p>
+      <div class="hl-ports"><span class="hl-port-tag">esp32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128104;&#127995;&#8205;&#128187;</span>
+      <h3>mpremote hash-based recursive copy</h3>
+      <p>New <code>mpremote sha256sum</code> command, plus recursive copy that
+        first hashes and only updates files that differ. Large-app sync becomes
+        fast.</p>
+      <div class="hl-ports"><span class="hl-port-tag">mpremote</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128279;</span>
+      <h3>SoftSPI LSB mode</h3>
+      <p><code>machine.SoftSPI</code> now supports least-significant-bit-first
+        ordering, in addition to MSB.</p>
+      <div class="hl-ports"><span class="hl-port-tag">machine</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#9888;</span>
+      <h3><code>sys.exit()</code> &mdash; breaking change</h3>
+      <p>Now triggers a <strong>soft reset</strong> of the device instead of just
+        dropping to the REPL. Brings bare-metal in line with the unix port. May
+        impact applications that relied on the old behaviour.</p>
+      <div class="hl-ports"><span class="hl-port-tag">core</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128300;</span>
+      <h3>STM32H7 OctoSPI</h3>
+      <p>OctoSPI memory-mapped flash support on STM32H7 MCUs. New
+        <code>ARDUINO_OPTA</code> stm32 board.</p>
+      <div class="hl-ports"><span class="hl-port-tag">stm32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127968;</span>
+      <h3>stm32: code in RAM for UART REPL</h3>
+      <p>Build option places IRQ + flash + UART code in RAM, enabled on boards with
+        a UART REPL so filesystem operations don't drop characters during flashing
+        (e.g. when copying files via mpremote).</p>
+      <div class="hl-ports"><span class="hl-port-tag">stm32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128100;</span>
+      <h3>Arduino + NXP SE05x secure element</h3>
+      <p><code>ARDUINO_PORTENTA_H7</code> and <code>ARDUINO_NICLA_VISION</code> gain
+        SE05x integration via mbedTLS &mdash; hardware-backed crypto.</p>
+      <div class="hl-ports"><span class="hl-port-tag">stm32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128300;</span>
+      <h3>zephyr v3.7 + threading</h3>
+      <p>Zephyr port updated to v3.7.0; threading via <code>_thread</code> is now
+        implemented. REPL is non-blocking. <code>_thread</code> tests now pass.
+        Big-int support enabled.</p>
+      <div class="hl-ports"><span class="hl-port-tag">zephyr</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128301;</span>
+      <h3>zephyr device-tree object construction</h3>
+      <p>Construct <code>machine</code> objects (Pin, I2C, SPI&hellip;) directly
+        from device-tree node labels, no more hard-coded peripheral indices.</p>
+      <div class="hl-ports"><span class="hl-port-tag">zephyr</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127817;</span>
+      <h3>qemu: ARM + RISC-V, with REPL</h3>
+      <p>The qemu port runs both architectures via a pty-based REPL, mirroring how
+        real bare-metal tests work. Tests that previously needed a board can now
+        run in CI.</p>
+      <div class="hl-ports"><span class="hl-port-tag">qemu</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128280;</span>
+      <h3>esp32: TCP socket cap</h3>
+      <p>Hard limit on active TCP sockets prevents resource exhaustion when
+        applications open sockets in quick succession.</p>
+      <div class="hl-ports"><span class="hl-port-tag">esp32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127760;</span>
+      <h3>webassembly FFI improvements</h3>
+      <p>JsProxy gains iterable-protocol proxying, identity reuse, no-existence-test
+        attribute lookup, and configurable pystack size. Top-level await of Task /
+        Event (covered in the language section above).</p>
+      <div class="hl-ports"><span class="hl-port-tag">webassembly</span></div>
+    </div>
+  </div>
+</section>

--- a/micropython-v1.24/v1.24.css
+++ b/micropython-v1.24/v1.24.css
@@ -1,0 +1,302 @@
+/* ============================================================
+   v1.24 page-specific styles
+   RP2350 chip diagram with ARM/RISC-V toggle, ipconfig
+   side-by-side, MCU spec cards (mirrors v1.26/v1.27 pattern),
+   language picker.
+   ============================================================ */
+
+/* ===== RP2350 architecture toggle ===== */
+.rp-arch-toggle {
+  display: inline-flex;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 3px;
+  margin-bottom: 20px;
+}
+.rp-arch-toggle button {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+.rp-arch-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.rp-stage {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.rp-svg {
+  width: 100%;
+  height: 240px;
+  display: block;
+}
+
+.rp-chip {
+  fill: var(--bg-tertiary);
+  stroke: var(--accent);
+  stroke-width: 2;
+  rx: 12;
+  transition: stroke 0.4s ease;
+}
+.rp-chip-label {
+  fill: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 800;
+  text-anchor: middle;
+}
+.rp-chip-sub {
+  fill: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  text-anchor: middle;
+}
+
+.rp-core {
+  fill: var(--bg-card);
+  stroke: var(--border);
+  stroke-width: 1.5;
+  rx: 6;
+  transition: stroke 0.4s ease, fill 0.4s ease;
+}
+.rp-core-label {
+  fill: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+.rp-core-sub {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-anchor: middle;
+}
+
+/* Architecture-specific colours */
+.rp-svg.arch-arm .rp-chip { stroke: var(--accent); }
+.rp-svg.arch-arm .rp-core { stroke: var(--accent); }
+.rp-svg.arch-arm .rp-arch-badge { fill: var(--accent); }
+.rp-svg.arch-riscv .rp-chip { stroke: var(--accent-purple); }
+.rp-svg.arch-riscv .rp-core { stroke: var(--accent-purple); }
+.rp-svg.arch-riscv .rp-arch-badge { fill: var(--accent-purple); }
+
+.rp-arch-badge {
+  rx: 4;
+  transition: fill 0.4s ease;
+}
+.rp-arch-badge-label {
+  fill: #fff;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 800;
+  text-anchor: middle;
+}
+
+.rp-info {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.rp-info-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.rp-info-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+.rp-info-value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.rp-info-value code {
+  font-size: 12px;
+}
+
+.rp-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 12px;
+  font-style: italic;
+}
+
+/* ===== RP2350 details bullets ===== */
+.rp-bullets {
+  list-style: none;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+.rp-bullets li {
+  padding: 4px 0;
+  position: relative;
+  padding-left: 20px;
+}
+.rp-bullets li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  color: var(--accent);
+}
+.rp-bullets strong {
+  color: var(--text-primary);
+}
+
+/* ===== ipconfig side-by-side ===== */
+.ip-side-by-side {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.ip-pane {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.ip-pane:nth-child(2) {
+  border-color: var(--accent-green);
+}
+.ip-pane-label {
+  padding: 10px 14px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+}
+.ip-pane-label strong {
+  color: var(--accent-green);
+}
+.ip-pre {
+  padding: 14px 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+/* ===== MCU spec cards (matches v1.26/v1.27 pattern) ===== */
+.mcu-spec-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+.mcu-spec-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  transition: all 0.2s ease;
+}
+.mcu-spec-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+.mcu-spec-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.mcu-spec-header h3 {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+.mcu-spec-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+.mcu-spec-strip > div {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.mcu-spec-num {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+.mcu-spec-desc {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.mcu-spec-boards {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ===== Language Picker (matches the v1.25-v1.27 pattern) ===== */
+.example-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.example-picker-row label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+.example-picker {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  cursor: pointer;
+  flex: 1;
+  max-width: 360px;
+}
+.example-picker:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .ip-side-by-side { grid-template-columns: 1fr; }
+  .rp-info { grid-template-columns: 1fr; }
+}

--- a/micropython-v1.24/v1.24.js
+++ b/micropython-v1.24/v1.24.js
@@ -1,0 +1,162 @@
+/* ============================================================
+   v1.24 page-specific behaviour
+   RP2350 ARM <-> RISC-V toggle, language example picker.
+   ============================================================ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  initRpArchToggle();
+  initLanguagePicker();
+});
+
+/* ===== RP2350 architecture toggle =====
+   RP2350 has both Cortex-M33 and Hazard3 RISC-V cores on the same die.
+   Flicking the toggle re-labels the core blocks and updates the
+   "what tools you get" info cards underneath. */
+
+const RP_CONFIGS = {
+  arm: {
+    coreLabel: 'Cortex-M33',
+    coreSub: 'core',
+    badge: 'ARM',
+    emitter: '@micropython.native -> Thumb v2',
+    asm: '@micropython.asm_thumb',
+    board: 'RPI_PICO2 (default ARM build)',
+  },
+  riscv: {
+    coreLabel: 'Hazard3',
+    coreSub: 'RV32IMC',
+    badge: 'RISC-V',
+    emitter: '@micropython.native -> RV32IMC',
+    asm: '@micropython.asm_rv32 (added in v1.25)',
+    board: 'RPI_PICO2 (RISC-V build)',
+  },
+};
+
+function initRpArchToggle() {
+  const buttons = document.querySelectorAll('.rp-arch-toggle button');
+  const svg = document.querySelector('.rp-svg');
+  if (!buttons.length || !svg) return;
+
+  const core0Label = document.getElementById('rp-core-0-label');
+  const core1Label = document.getElementById('rp-core-1-label');
+  const core0Sub = document.getElementById('rp-core-0-sub');
+  const core1Sub = document.getElementById('rp-core-1-sub');
+  const badge = document.getElementById('rp-arch-badge-label');
+  const infoEmitter = document.getElementById('rp-info-emitter');
+  const infoAsm = document.getElementById('rp-info-asm');
+  const infoBoard = document.getElementById('rp-info-board');
+
+  function setArch(arch) {
+    const cfg = RP_CONFIGS[arch];
+    if (!cfg) return;
+    buttons.forEach(b => b.classList.toggle('active', b.dataset.arch === arch));
+    svg.classList.remove('arch-arm', 'arch-riscv');
+    svg.classList.add('arch-' + arch);
+    core0Label.textContent = cfg.coreLabel;
+    core1Label.textContent = cfg.coreLabel;
+    core0Sub.textContent = cfg.coreSub + ' 0';
+    core1Sub.textContent = cfg.coreSub + ' 1';
+    badge.textContent = cfg.badge;
+    infoEmitter.innerHTML = '<code>' + cfg.emitter + '</code>';
+    infoAsm.innerHTML = '<code>' + cfg.asm + '</code>';
+    infoBoard.textContent = cfg.board;
+  }
+
+  buttons.forEach(b => b.addEventListener('click', () => setArch(b.dataset.arch)));
+  setArch('arm');
+}
+
+/* ===== Language Example Picker ===== */
+
+const LANG_EXAMPLES = {
+  fstring_concat: {
+    note: 'In v1.24, adjacent f-string literals are concatenated at parse time -- like regular string literals have always been.',
+    code: `# v1.24: adjacent f-strings concatenate.
+name = "world"
+n = 42
+
+# These three literal forms are now equivalent at parse time:
+greet1 = f"hello, {name}!"
+greet2 = f"hello, " f"{name}!"
+greet3 = (
+    f"hello, "
+    f"{name}"
+    f"!"
+)
+
+print(greet1)
+print(greet2)
+print(greet3)
+print("equal:", greet1 == greet2 == greet3)
+
+# Useful for breaking up a long f-string across lines without runtime '+' overhead.
+msg = (
+    f"item={name!r} "
+    f"count={n} "
+    f"hex={n:#x}"
+)
+print(msg)
+`
+  },
+  raw_fstring: {
+    note: 'Raw f-strings (rf"...") combine raw-string semantics (no backslash escapes) with f-string interpolation. Useful for regex patterns and Windows paths.',
+    code: `# v1.24: raw f-strings -- backslashes pass through, {} still interpolate.
+import re
+
+pattern_name = "digit"
+
+# Ordinary f-string: \\d would fail / get unescaped
+# Raw f-string: \\d is literally a backslash + d, but {pattern_name} still substitutes
+pat = rf"(?P<{pattern_name}>\\d+)"
+print("Pattern:", pat)
+
+m = re.match(pat, "abc123def")  # Won't match -- starts with abc
+print("match abc123def:", m)
+m = re.match(pat, "123abc")
+print("match 123abc:   ", m.group(pattern_name) if m else None)
+
+# Useful for Windows-style paths
+drive = "C:"
+print(rf"{drive}\\Users\\Public\\file.txt")
+`
+  },
+  sysexit: {
+    note: 'BREAKING CHANGE in v1.24: sys.exit() (and "raise SystemExit") now triggers a soft reset of the device on bare-metal ports, instead of dropping to the REPL. The pyscript variant still surfaces it as an exception -- this in-browser demo just shows the exception flow.',
+    code: `# In v1.24+, on a real device (rp2, stm32, esp32, ...), running this script
+# directly would soft-reset the device on the sys.exit() call.
+# The pyscript variant raises SystemExit which our runner catches as an
+# Exception -- close enough to show the shape.
+
+import sys
+
+print("about to exit -- in v1.23, this dropped to the REPL")
+print("                 in v1.24, this triggers a soft reset on bare metal")
+
+try:
+    sys.exit("bye!")
+except SystemExit as e:
+    # We catch it here so the demo can keep printing.
+    print(f"caught SystemExit (code = {e.code!r})")
+
+print("execution continues only because we caught it explicitly")
+`
+  },
+};
+
+function initLanguagePicker() {
+  const picker = document.getElementById('lang-picker');
+  const editor = document.getElementById('lang-editor');
+  const note = document.getElementById('lang-note');
+  const reset = document.getElementById('lang-reset');
+  if (!picker || !editor) return;
+
+  function load(key) {
+    const ex = LANG_EXAMPLES[key];
+    if (!ex) return;
+    editor.value = ex.code;
+    note.textContent = ex.note;
+  }
+  picker.addEventListener('change', () => load(picker.value));
+  reset.addEventListener('click', () => load(picker.value));
+  load(picker.value);
+}

--- a/micropython-v1.25/index.html
+++ b/micropython-v1.25/index.html
@@ -1,0 +1,531 @@
+---
+layout: release-notes
+title: MicroPython v1.25.0 Release Notes
+version: v1.25.0
+pyscript: true
+page_css: /micropython-v1.25/v1.25.css
+page_js: /micropython-v1.25/v1.25.js
+
+hero:
+  version: "v1.25"
+  tagline: "ROMFS ships after three years in development, plus a brand-new alif port and an inline RISC-V assembler."
+  date: "April 16, 2025"
+
+summary_cards:
+  - { icon: "&#128190;", title: "ROMFS",     desc: "Execute mpy in place from flash",    target: "romfs" }
+  - { icon: "&#129504;", title: "alif port", desc: "Ethos-U55 ML accelerators",          target: "alif" }
+  - { icon: "&#9881;",   title: "asm_rv32",  desc: "Inline RISC-V 32-bit machine code",  target: "asm" }
+  - { icon: "&#128274;", title: "DTLS",      desc: "Datagram TLS over UDP sockets",      target: "dtls" }
+
+stats:
+  - { value: 56, label: "Contributors" }
+  - { value: 15, label: "Timezones" }
+  - { value: 19, label: "New Boards" }
+
+mpy_banner:
+  headline: "The language demos on this page run real MicroPython in your browser."
+  body: "MicroPython is compiled to WebAssembly via PyScript and executes live as the page loads &mdash; no server required."
+
+toc:
+  - { id: "romfs",    label: "ROMFS / VfsRom" }
+  - { id: "alif",     label: "alif port" }
+  - { id: "asm",      label: "asm_rv32" }
+  - { id: "dtls",     label: "DTLS" }
+  - { id: "language", label: "Language Tweaks" }
+  - { id: "highlights", label: "Highlights" }
+
+boards:
+  summary: "19 new board definitions, dominated by RP2350-class rp2 boards and the brand-new alif port."
+  groups:
+    - port: "alif"
+      boards: ["ALIF_ENSEMBLE", "OPENMV_AE3"]
+    - port: "mimxrt"
+      boards: ["MAKERDIARY_RT1011_NANO_KIT"]
+    - port: "rp2"
+      boards:
+        - "MACHDYNE_WERKZEUG"
+        - "RPI_PICO2_W"
+        - "SEEED_XIAO_RP2350"
+        - "SPARKFUN_IOTNODE_LORAWAN_RP2350"
+        - "SPARKFUN_IOTREDBOARD_RP2350"
+        - "SPARKFUN_PROMICRO_RP2350"
+        - "SPARKFUN_THINGPLUS_RP2350"
+        - "SPARKFUN_XRP_CONTROLLER"
+        - "SPARKFUN_XRP_CONTROLLER_BETA"
+        - "WEACTSTUDIO_RP2350B_CORE"
+    - port: "samd"
+      boards:
+        - "ADAFRUIT_NEOKEY_TRINKEY"
+        - "ADAFRUIT_QTPY_SAMD21"
+        - "SAMD_GENERIC_D21X18"
+        - "SAMD_GENERIC_D51X19"
+        - "SAMD_GENERIC_D51X2"
+    - port: "stm32"
+      boards: ["WEACT_F411_BLACKPILL"]
+
+numbers:
+  summary: "v1.25 in numbers. unix and mimxrt take big code-size hits from VfsRom + exFAT; rp2 grows for DTLS + cyw43-driver 1.1.0."
+  cards:
+    - { value: 56, label: "Contributors" }
+    - { value: 15, label: "Timezones" }
+    - { value: 19, label: "New Boards" }
+  code_size:
+    title: "Code size delta vs v1.24 (.text section, bytes)"
+    rows:
+      - { port: "unix x64",   delta_bytes: 16941, bar_pct: 100, tooltip: "+2.05% &mdash; enable VfsRom, mbedTLS v3.6.2, DTLS" }
+      - { port: "esp32",      delta_bytes: 10956, bar_pct: 65,  tooltip: "+0.65% &mdash; many small fixes and improvements" }
+      - { port: "rp2",        delta_bytes: 7944,  bar_pct: 47,  tooltip: "+0.87% &mdash; mbedTLS v3.6.2, DTLS, cyw43-driver 1.1.0" }
+      - { port: "mimxrt",     delta_bytes: 7508,  bar_pct: 44,  tooltip: "+2.07% &mdash; enable exFAT, function constructor" }
+      - { port: "samd",       delta_bytes: 1112,  bar_pct: 7,   tooltip: "+0.42% &mdash; UART 9-bit, function constructor, default buses" }
+      - { port: "esp8266",    delta_bytes: 964,   bar_pct: 6,   tooltip: "+0.14% &mdash; function attrs, Pin.toggle(), AP enumeration" }
+      - { port: "cc3200",     delta_bytes: 280,   bar_pct: 2,   tooltip: "+0.15% &mdash; Pin.toggle()" }
+      - { port: "nrf",        delta_bytes: 168,   bar_pct: 1,   tooltip: "+0.09% &mdash; sys.implementation._build, 2-arg next(), vfs.mount()" }
+      - { port: "bare-arm",   delta_bytes: 4,     bar_pct: 1,   tooltip: "+0.01% &mdash; tracking only" }
+      - { port: "minimal x86",delta_bytes: -90,   bar_pct: 1,   tooltip: "-0.05% &mdash; small code-size optimisations" }
+      - { port: "stm32",      delta_bytes: -96,   bar_pct: 1,   tooltip: "-0.03% &mdash; small code-size optimisations" }
+      - { port: "renesas-ra", delta_bytes: -160,  bar_pct: 1,   tooltip: "-0.03% &mdash; small code-size optimisations" }
+  contributors: |
+    Alessandro Gatti, Alex Brudner, Amirreza Hamzavi, Andrew Leech, Angus Gratton,
+    Anson Mansfield, Carl Pottle, Christian Clauss, chuangjinglu, Corran Webster,
+    Damien George, danicampora, Dani&euml;l van de Giessen, Dryw Wade, eggfly,
+    Garry W, garywill, Glenn Moloney, Glenn Strauss, Graeme Winter, Hans Maerki,
+    Herwin Grobben, I. Tomita, iabdalkader, IhorNehrutsa, Jan Klus&aacute;&ccaron;ek,
+    Jan Sturm, Jared Hancock, Jeff Epler, Jon Nordby, Jos Verlinde, Karl Palsson,
+    Keenan Johnson, Kwabena W. Agyeman, Lesords, machdyne, Malcolm McKellips,
+    Mark Seminatore, Markus Gyger, Matt Trentini, Mike Bell, Neil Ludban,
+    Peter Harper, peterhinch, Phil Howard, robert-hh, Ronald Weber, rufusclark,
+    Sebastian Romero, Steve Holden, stijn, StrayCat, Thomas Watson,
+    Victor Rajewski, Volodymyr Shymanskyy, Yoctopuce.
+
+pyscript_block: |
+  from pyscript import document, when
+  import sys
+
+  def run_editor(code_id, out_id):
+      code = document.querySelector("#" + code_id).value
+      out_el = document.querySelector("#" + out_id)
+      out_el.classList.remove("has-error")
+      lines = []
+      def _print(*args, sep=" ", end="\n"):
+          lines.append(sep.join(str(a) for a in args) + end)
+      try:
+          exec(code, {"print": _print})
+          output = "".join(lines) or "(no output)"
+      except Exception as e:
+          output = type(e).__name__ + ": " + str(e)
+          out_el.classList.add("has-error")
+      out_el.innerText = output
+
+  @when("click", "#lang-run")
+  def _r_lang(ev):
+      run_editor("lang-editor", "lang-output")
+
+  for s in document.querySelectorAll(".mpy-status"):
+      s.innerText = f"MicroPython {sys.version} ready"
+---
+
+<!-- ===== SECTION: ROMFS ===== -->
+<section class="section" id="romfs">
+  <div class="section-header">
+    <span class="section-badge new">New &mdash; 3 years in development</span>
+    <h2>ROMFS &mdash; Execute Bytecode in Place</h2>
+    <p class="section-desc">
+      <strong>ROMFS</strong> is a read-only, memory-mappable filesystem that lets MicroPython
+      execute precompiled <code>.mpy</code> bytecode <em>directly from flash</em>, without
+      copying it into RAM first. The result: faster imports and a lot less heap pressure.
+      Data resources like fonts can also be used in place. ROMFS builds on bytecode v6
+      (which has supported in-place execution for years).
+    </p>
+  </div>
+
+  <div class="demo-container">
+    <div class="demo-label">Interactive Demo &mdash; Import a Module</div>
+
+    <div class="romfs-controls">
+      <button class="btn btn-primary" id="romfs-run">Run <code>import font</code></button>
+      <button class="btn btn-secondary" id="romfs-reset">Reset</button>
+    </div>
+
+    <div class="romfs-stage">
+      <!-- Without ROMFS (left) -->
+      <div class="romfs-mcu">
+        <div class="romfs-mcu-title">Without ROMFS &mdash; bytecode copies to RAM</div>
+        <svg class="romfs-mcu-svg" viewBox="0 0 280 180" preserveAspectRatio="xMidYMid meet">
+          <rect x="20"  y="20"  width="240" height="64" class="romfs-flash"/>
+          <text x="140" y="42"  class="romfs-region-label">FLASH (.mpy bytecode)</text>
+          <rect x="40"  y="50"  width="60"  height="20" class="romfs-bytecode" id="romfs-flash-a"/>
+          <rect x="180" y="50"  width="60"  height="20" class="romfs-bytecode" id="romfs-flash-b"/>
+
+          <rect x="20"  y="100" width="240" height="64" class="romfs-ram"/>
+          <text x="140" y="122" class="romfs-region-label">RAM</text>
+          <text x="140" y="148" class="romfs-ram-used" id="romfs-ram-used-a">0 kB used</text>
+
+          <!-- Animated copy block -->
+          <rect class="romfs-copy" id="romfs-copy-a" width="60" height="20" style="display:none;"/>
+        </svg>
+      </div>
+
+      <!-- With ROMFS (right) -->
+      <div class="romfs-mcu">
+        <div class="romfs-mcu-title">With ROMFS &mdash; bytecode runs in place</div>
+        <svg class="romfs-mcu-svg" viewBox="0 0 280 180" preserveAspectRatio="xMidYMid meet">
+          <rect x="20"  y="20"  width="240" height="64" class="romfs-flash romfs-flash-romfs"/>
+          <text x="140" y="42"  class="romfs-region-label">FLASH /rom (mmapped)</text>
+          <rect x="40"  y="50"  width="60"  height="20" class="romfs-bytecode" id="romfs-rom-a"/>
+          <rect x="180" y="50"  width="60"  height="20" class="romfs-bytecode" id="romfs-rom-b"/>
+
+          <rect x="20"  y="100" width="240" height="64" class="romfs-ram"/>
+          <text x="140" y="122" class="romfs-region-label">RAM</text>
+          <text x="140" y="148" class="romfs-ram-used" id="romfs-ram-used-b">0 kB used</text>
+
+          <!-- "Execute in place" arrow -->
+          <path id="romfs-inplace-arrow" d="M 70 70 L 70 100" class="romfs-inplace" style="display:none;"/>
+          <text x="80" y="92" class="romfs-inplace-label" id="romfs-inplace-label" style="display:none;">execute in place</text>
+        </svg>
+      </div>
+    </div>
+
+    <p class="romfs-note">
+      The demo simulates a small import. In real MicroPython, bytecode v6 + ROMFS lets the
+      VM execute opcodes directly from a memory-mapped flash region; only the per-call frame
+      needs to live in RAM. Imports of large modules become noticeably faster.
+    </p>
+  </div>
+
+  <h3 style="font-size:18px; margin-top:24px; margin-bottom:12px;">Building &amp; deploying ROMFS &mdash; <code>mpremote</code></h3>
+  <div class="code-block">
+    <div class="code-header">
+      <span>terminal</span>
+      <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+    </div>
+<pre><span class="cmt"># 1. Build a ROMFS image from a directory tree of .py / .mpy / data files</span>
+$ mpremote romfs build romfs.bin --src ./assets
+Built ROMFS image: 32 kB
+
+<span class="cmt"># 2. Deploy it to the /rom partition on the target device</span>
+$ mpremote romfs deploy romfs.bin
+Deployed to /rom
+
+<span class="cmt"># 3. Imports now resolve transparently from /rom</span>
+$ mpremote run app.py</pre>
+  </div>
+
+  <h3 style="font-size:18px; margin-top:24px; margin-bottom:12px;">Where ROMFS is enabled by default in v1.25</h3>
+  <p style="font-size:14px; color:var(--text-secondary); margin-bottom:12px;">
+    Other boards can opt in with manual configuration. The list will grow in subsequent releases.
+  </p>
+  <div class="port-matrix">
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> PYBD-SFx (stm32)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> alif (all boards)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> ESP8266 FLASH_2M_ROMFS variant</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> stm32 Arduino boards</div>
+  </div>
+</section>
+
+<!-- ===== SECTION: ALIF PORT ===== -->
+<section class="section" id="alif">
+  <div class="section-header">
+    <span class="section-badge new">Brand new port</span>
+    <h2>alif &mdash; Multi-core ARM with ML Accelerators</h2>
+    <p class="section-desc">
+      A new port targeting Alif Semiconductor's <strong>Ensemble</strong> family. These MCUs
+      pair multiple ARM cores with <strong>Ethos-U55</strong> machine-learning accelerators
+      and a generous peripheral set. v1.25 brings up the platform with TinyUSB,
+      <strong>OpenAMP-based dual-core support</strong>, octal-SPI flash with XIP, and the
+      <code>machine</code> classes plus cyw43 WiFi+BLE.
+    </p>
+  </div>
+
+  <div class="mcu-spec-cards">
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>Alif Ensemble</h3>
+        <span class="badge active">Multi-core ARM</span>
+      </div>
+      <div class="mcu-spec-strip">
+        <div><span class="mcu-spec-num">M55</span> + M0+</div>
+        <div><span class="mcu-spec-num">U55</span> NPU</div>
+        <div><span class="mcu-spec-num">XIP</span> octal flash</div>
+      </div>
+      <p class="mcu-spec-desc">
+        Targeted at battery-powered ML inference at the edge. v1.25 supports
+        <code>Pin</code>, <code>UART</code>, <code>SPI</code>, <code>I2C</code>, USB via
+        TinyUSB, and dual-core orchestration via OpenAMP. cyw43 WiFi and BLE work on
+        boards that include the radio module.
+      </p>
+      <div class="mcu-spec-boards">
+        <span class="board-chip">ALIF_ENSEMBLE</span>
+        <span class="board-chip">OPENMV_AE3</span>
+      </div>
+    </div>
+
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>What's running where</h3>
+        <span class="badge active">Dual-core via OpenAMP</span>
+      </div>
+      <ul class="alif-bullets">
+        <li><strong>Cortex-M55 (HE)</strong> &mdash; high-performance core where MicroPython
+            executes by default.</li>
+        <li><strong>Cortex-M0+ (LP)</strong> &mdash; low-power core; OpenAMP makes it
+            addressable from MicroPython.</li>
+        <li><strong>Ethos-U55 NPU</strong> &mdash; per-core neural-network accelerator;
+            not yet exposed at the Python layer in v1.25.</li>
+        <li><strong>OPENMV_AE3</strong> targets OpenMV's upcoming AE3 camera board &mdash; the
+            ML angle is the headline use case.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ===== SECTION: asm_rv32 ===== -->
+<section class="section" id="asm">
+  <div class="section-header">
+    <span class="section-badge new">New decorator</span>
+    <h2><code>@micropython.asm_rv32</code> &mdash; Inline RISC-V 32-bit assembly</h2>
+    <p class="section-desc">
+      MicroPython's inline-assembler family gains <strong>RV32</strong>. Write small snippets
+      of 32-bit RISC-V machine code as Python functions. Currently enabled on the rp2 port
+      when the <strong>RP2350 is in RISC-V mode</strong>.
+    </p>
+  </div>
+
+  <div class="asm-side-by-side">
+    <div class="asm-pane">
+      <div class="asm-pane-label">Pure Python (Viper)</div>
+<pre class="asm-pre"><span class="kw">@micropython.viper</span>
+<span class="kw">def</span> <span class="fn">add_squared</span>(a: <span class="bi">int</span>, b: <span class="bi">int</span>) -&gt; <span class="bi">int</span>:
+    <span class="kw">return</span> a*a + b*b</pre>
+    </div>
+    <div class="asm-pane">
+      <div class="asm-pane-label">Inline RV32 assembly</div>
+<pre class="asm-pre"><span class="kw">@micropython.asm_rv32</span>
+<span class="kw">def</span> <span class="fn">add_squared</span>(a0, a1) -&gt; <span class="bi">int</span>:
+    <span class="cmt"># a0 *= a0      ; a0 = a*a</span>
+    mul(a0, a0, a0)
+    <span class="cmt"># a1 *= a1      ; a1 = b*b</span>
+    mul(a1, a1, a1)
+    <span class="cmt"># a0 += a1      ; return a*a + b*b</span>
+    add(a0, a0, a1)</pre>
+    </div>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">Where it works</div>
+    The <code>asm_rv32</code> decorator is enabled on <strong>rp2</strong> when targeting
+    RP2350 in RISC-V mode (Hazard3 cores). The same release also extends the native
+    emitter and <code>mpy_ld.py</code> linker to support 32-bit RISC-V code generation
+    and static-library linking, so native modules can be built for RV32 targets.
+  </div>
+</section>
+
+<!-- ===== SECTION: DTLS ===== -->
+<section class="section" id="dtls">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>DTLS &mdash; Datagram TLS</h2>
+    <p class="section-desc">
+      The <code>tls</code> module gains <code>PROTOCOL_DTLS_CLIENT</code> and
+      <code>PROTOCOL_DTLS_SERVER</code> modes. Wrap a UDP socket in a DTLS context
+      and you have an authenticated, encrypted datagram channel &mdash; useful for
+      CoAP-secure, low-latency telemetry, and constrained-network protocols where
+      TCP is the wrong tool.
+    </p>
+  </div>
+
+  <div class="dtls-compare">
+    <div class="dtls-pane">
+      <div class="dtls-pane-label">TLS over TCP &mdash; familiar</div>
+<pre class="dtls-pre"><span class="kw">import</span> tls, socket
+
+ctx = tls.SSLContext(tls.PROTOCOL_TLS_CLIENT)
+ctx.load_verify_locations(cadata=ca)
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((<span class="str">"example.com"</span>, <span class="num">443</span>))
+ss = ctx.wrap_socket(s, server_hostname=<span class="str">"example.com"</span>)
+ss.send(<span class="str">b"GET / HTTP/1.0\r\n\r\n"</span>)</pre>
+    </div>
+    <div class="dtls-pane">
+      <div class="dtls-pane-label">DTLS over UDP &mdash; <strong>new in v1.25</strong></div>
+<pre class="dtls-pre"><span class="kw">import</span> tls, socket
+
+ctx = tls.SSLContext(tls.<span class="op">PROTOCOL_DTLS_CLIENT</span>)
+ctx.load_verify_locations(cadata=ca)
+
+s = socket.socket(socket.AF_INET, socket.<span class="op">SOCK_DGRAM</span>)
+s.connect((<span class="str">"sensor.example"</span>, <span class="num">5684</span>))
+ss = ctx.wrap_socket(s, server_hostname=<span class="str">"sensor.example"</span>)
+ss.send(<span class="str">b"telemetry payload"</span>)</pre>
+    </div>
+  </div>
+
+  <h3 style="font-size:18px; margin-top:24px; margin-bottom:12px;">DTLS Port Support</h3>
+  <div class="port-matrix">
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> alif</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> mimxrt</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> renesas-ra</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> rp2</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> stm32</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> unix</div>
+  </div>
+</section>
+
+<!-- ===== SECTION: LANGUAGE TWEAKS ===== -->
+<section class="section" id="language">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>Python language tweaks</h2>
+    <p class="section-desc">
+      Five small core-language additions in v1.25. Pick one from the dropdown to load
+      the example into the editor, then run it live.
+    </p>
+  </div>
+
+  <div class="demo-container live-playground">
+    <div class="demo-label">
+      Live demo
+      <span class="pyscript-tag">PyScript</span>
+    </div>
+
+    <div class="example-picker-row">
+      <label for="lang-picker">Example:</label>
+      <select id="lang-picker" class="example-picker">
+        <option value="startswith">str.startswith / endswith with tuple + start/end</option>
+        <option value="next2">2-arg next() with default</option>
+        <option value="vfsmount">vfs.mount() with no arguments</option>
+        <option value="funccode">function.__code__ and function constructor</option>
+        <option value="implbuild">sys.implementation._build</option>
+      </select>
+    </div>
+
+    <textarea class="mpy-code-editor" id="lang-editor" spellcheck="false"></textarea>
+    <div class="mpy-btn-row">
+      <button class="mpy-run-btn" id="lang-run">Run &#9654;</button>
+      <button class="mpy-clear-btn" id="lang-reset">Reset example</button>
+      <span class="mpy-status">Loading MicroPython&hellip;</span>
+    </div>
+    <div class="mpy-output" id="lang-output"></div>
+
+    <p class="playground-note" id="lang-note"></p>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">marshal: enabled, but not in this build</div>
+    v1.25 also added a <code>marshal</code> module with <code>dumps()</code> /
+    <code>loads()</code> for code objects &mdash; combined with <code>function.__code__</code>
+    that gives you function serialisation. The MicroPython release tag explicitly notes:
+    <em>"This module is not enabled by default but can be used in custom build
+    configurations."</em> The PyScript variant of MicroPython runs at the
+    <code>FULL_FEATURES</code> ROM level, which doesn't include <code>marshal</code> &mdash;
+    so we can't demo it here. Try it on a desktop unix build with
+    <code>MICROPY_PY_MARSHAL=1</code>.
+  </div>
+</section>
+
+<!-- ===== SECTION: HIGHLIGHTS ===== -->
+<section class="section" id="highlights">
+  <div class="section-header">
+    <h2>Highlights</h2>
+    <p class="section-desc">Other notable improvements in v1.25.</p>
+  </div>
+
+  <div class="highlights-grid">
+    <div class="highlight-card">
+      <span class="hl-icon">&#128465;</span>
+      <h3><code>mpremote rm -r</code></h3>
+      <p>Recursive remove on the target device. <code>mpremote rm -rv :</code> wipes the
+        current working directory.</p>
+      <div class="hl-ports"><span class="hl-port-tag">mpremote</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128230;</span>
+      <h3><code>mip install</code> from local FS</h3>
+      <p>Install a package from a local directory or relative URL via
+        <code>package.json</code>. Useful for offline / air-gapped setups.</p>
+      <div class="hl-ports"><span class="hl-port-tag">mpremote</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128279;</span>
+      <h3>Default I2C / SPI / UART buses</h3>
+      <p>On samd, mimxrt, rp2 and others, the bus-id argument is now optional &mdash;
+        cross-port code can drop the explicit <code>id</code>.</p>
+      <div class="hl-ports"><span class="hl-port-tag">machine</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128268;</span>
+      <h3>esp32 dynamic USB devices</h3>
+      <p>USB device configuration at runtime on ESP32-S2 / S3, plus IDF v5.3 / v5.4 support
+        (sub-5.2.0 dropped). I2S enabled on all C3 boards.</p>
+      <div class="hl-ports"><span class="hl-port-tag">esp32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127960;</span>
+      <h3>RP2350 PSRAM autodetection</h3>
+      <p>RP2350 boards with PSRAM auto-size on boot. <code>rp2.bootsel_button()</code>
+        and USB-during-sleep both work on RP2350.</p>
+      <div class="hl-ports"><span class="hl-port-tag">rp2</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128272;</span>
+      <h3>WPA3 on cyw43 boards</h3>
+      <p>Pico W, Pico 2 W and stm32 cyw43-driver boards now support WPA3 in both AP
+        and STA modes.</p>
+      <div class="hl-ports"><span class="hl-port-tag">rp2</span><span class="hl-port-tag">stm32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#9888;</span>
+      <h3>stm32 deinit on soft-reset &mdash; breaking</h3>
+      <p>I2C and SPI buses are now deinitialised on soft-reset. Always re-initialise
+        instances when creating them.</p>
+      <div class="hl-ports"><span class="hl-port-tag">stm32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128203;</span>
+      <h3>littlefs corruption recovery</h3>
+      <p>stm32 boots no longer hard-fault on corrupt filesystems. Falls back to default
+        block parameters, then prints a message and continues.</p>
+      <div class="hl-ports"><span class="hl-port-tag">stm32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#9881;</span>
+      <h3>zephyr Timer + WDT</h3>
+      <p>The zephyr port gains <code>machine.Timer</code> and <code>machine.WDT</code>
+        implementations, narrowing the cross-port API gap.</p>
+      <div class="hl-ports"><span class="hl-port-tag">zephyr</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128229;</span>
+      <h3>mimxrt UF2 + exFAT + PPP</h3>
+      <p>UF2 bootloader support for easier firmware deployment, exFAT filesystem,
+        and PPP driver for boards with lwIP networking.</p>
+      <div class="hl-ports"><span class="hl-port-tag">mimxrt</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128268;</span>
+      <h3>RV32 native modules</h3>
+      <p><code>mpy_ld.py</code> now supports 32-bit RISC-V code, plus automatic linking
+        of static libraries (<code>libgcc</code>, <code>libm</code>) so native modules
+        can use standard C functions like <code>exp()</code>.</p>
+      <div class="hl-ports"><span class="hl-port-tag">native modules</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128737;</span>
+      <h3>mboot version string</h3>
+      <p>stm32 mboot embeds a version at the end of its flash slot;
+        <code>fwupdate.get_mboot_version()</code> retrieves it.</p>
+      <div class="hl-ports"><span class="hl-port-tag">stm32</span></div>
+    </div>
+  </div>
+</section>

--- a/micropython-v1.25/v1.25.css
+++ b/micropython-v1.25/v1.25.css
@@ -1,0 +1,304 @@
+/* ============================================================
+   v1.25 page-specific styles
+   ROMFS two-MCU diagram, alif bullets, asm side-by-side,
+   DTLS comparison, language picker (reuses the v1.26 pattern).
+   ============================================================ */
+
+/* ===== ROMFS Demo ===== */
+.romfs-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.romfs-stage {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.romfs-mcu {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.romfs-mcu-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.romfs-mcu-svg {
+  width: 100%;
+  height: 180px;
+  display: block;
+}
+
+.romfs-flash {
+  fill: var(--bg-tertiary);
+  stroke: var(--text-muted);
+  stroke-width: 1;
+  rx: 4;
+}
+.romfs-flash-romfs {
+  stroke: var(--accent-green);
+  stroke-width: 2;
+  stroke-dasharray: 6 4;
+}
+
+.romfs-ram {
+  fill: var(--bg-card);
+  stroke: var(--accent);
+  stroke-width: 1;
+  rx: 4;
+}
+
+.romfs-region-label {
+  fill: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.romfs-bytecode {
+  fill: var(--accent);
+  rx: 3;
+  opacity: 0.85;
+}
+
+.romfs-ram-used {
+  fill: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  text-anchor: middle;
+  font-variant-numeric: tabular-nums;
+}
+
+.romfs-copy {
+  fill: var(--accent-orange);
+  rx: 3;
+}
+
+.romfs-inplace {
+  fill: none;
+  stroke: var(--accent-green);
+  stroke-width: 2;
+  marker-end: url(#romfs-arrow-head);
+}
+.romfs-inplace-label {
+  fill: var(--accent-green);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.romfs-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+  margin-top: 8px;
+}
+
+/* ===== alif bullets ===== */
+.alif-bullets {
+  list-style: none;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+.alif-bullets li {
+  padding: 4px 0;
+  position: relative;
+  padding-left: 20px;
+}
+.alif-bullets li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  color: var(--accent);
+}
+.alif-bullets strong {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+/* ===== asm_rv32 side-by-side ===== */
+.asm-side-by-side {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.asm-pane {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.asm-pane:nth-child(2) {
+  border-color: var(--accent);
+}
+.asm-pane-label {
+  padding: 10px 14px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+}
+.asm-pre {
+  padding: 14px 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+/* ===== DTLS comparison ===== */
+.dtls-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.dtls-pane {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.dtls-pane:nth-child(2) {
+  border-color: var(--accent-green);
+}
+.dtls-pane-label {
+  padding: 10px 14px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+}
+.dtls-pane-label strong {
+  color: var(--accent-green);
+}
+.dtls-pre {
+  padding: 14px 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+/* ===== Language Picker (matches v1.26/v1.27 pattern) ===== */
+.example-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.example-picker-row label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+.example-picker {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  cursor: pointer;
+  flex: 1;
+  max-width: 420px;
+}
+.example-picker:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ===== MCU spec cards (mirrors the v1.26/v1.27 pattern) ===== */
+.mcu-spec-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+.mcu-spec-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  transition: all 0.2s ease;
+}
+.mcu-spec-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+.mcu-spec-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.mcu-spec-header h3 {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+.mcu-spec-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+.mcu-spec-strip > div {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.mcu-spec-num {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+.mcu-spec-desc {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.mcu-spec-boards {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .romfs-stage { grid-template-columns: 1fr; }
+  .asm-side-by-side { grid-template-columns: 1fr; }
+  .dtls-compare { grid-template-columns: 1fr; }
+}

--- a/micropython-v1.25/v1.25.js
+++ b/micropython-v1.25/v1.25.js
@@ -1,0 +1,201 @@
+/* ============================================================
+   v1.25 page-specific behaviour
+   ROMFS import animation, language example picker.
+   ============================================================ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  initRomfsDemo();
+  initLanguagePicker();
+});
+
+/* ===== ROMFS Demo =====
+   Two side-by-side simulated MCUs. Click "Run import" -- the left MCU
+   animates a copy from FLASH to RAM (cost: ~6 kB of RAM), the right MCU
+   shows execute-in-place (cost: 0 kB of RAM). */
+
+function initRomfsDemo() {
+  const runBtn = document.getElementById('romfs-run');
+  const resetBtn = document.getElementById('romfs-reset');
+  if (!runBtn) return;
+
+  const ramUsedA = document.getElementById('romfs-ram-used-a');
+  const ramUsedB = document.getElementById('romfs-ram-used-b');
+  const flashA = document.getElementById('romfs-flash-a');
+  const romA = document.getElementById('romfs-rom-a');
+  const copyEl = document.getElementById('romfs-copy-a');
+  const arrow = document.getElementById('romfs-inplace-arrow');
+  const arrowLabel = document.getElementById('romfs-inplace-label');
+
+  let runAnim = null;
+  let nextImport = 0; // 0 = font, 1 = data
+  const imports = [
+    { label: 'font', kb: 6, sourceX: 40, sourceY: 50 },
+    { label: 'data', kb: 4, sourceX: 180, sourceY: 50 },
+  ];
+  let totalKbA = 0;
+
+  function reset() {
+    if (runAnim) cancelAnimationFrame(runAnim);
+    nextImport = 0;
+    totalKbA = 0;
+    ramUsedA.textContent = '0 kB used';
+    ramUsedB.textContent = '0 kB used';
+    copyEl.style.display = 'none';
+    arrow.style.display = 'none';
+    arrowLabel.style.display = 'none';
+    flashA.style.opacity = '0.85';
+    if (romA) romA.style.opacity = '0.85';
+  }
+
+  function runImport() {
+    const imp = imports[nextImport % imports.length];
+    nextImport++;
+
+    // Right MCU: instant in-place reveal (no animation, just show the arrow on first import)
+    arrow.style.display = '';
+    arrowLabel.style.display = '';
+    arrow.setAttribute('d', `M ${imp.sourceX + 30} 70 L ${imp.sourceX + 30} 100`);
+    arrowLabel.setAttribute('x', imp.sourceX + 36);
+    arrowLabel.setAttribute('y', 92);
+    ramUsedB.textContent = '0 kB used';
+
+    // Left MCU: animate a block flying from flash to RAM
+    copyEl.style.display = '';
+    copyEl.setAttribute('width', '60');
+    const startX = imp.sourceX;
+    const startY = imp.sourceY;
+    const endX = 40 + (totalKbA / 16) * 200; // RAM fills left-to-right
+    const endY = 130;
+    const t0 = performance.now();
+    const duration = 900;
+
+    function step(t) {
+      const p = Math.min((t - t0) / duration, 1);
+      const ease = 1 - Math.pow(1 - p, 3);
+      const x = startX + (endX - startX) * ease;
+      const y = startY + (endY - startY) * ease;
+      copyEl.setAttribute('x', x);
+      copyEl.setAttribute('y', y);
+      if (p < 1) {
+        runAnim = requestAnimationFrame(step);
+      } else {
+        copyEl.style.display = 'none';
+        totalKbA += imp.kb;
+        ramUsedA.textContent = `${totalKbA} kB used`;
+        // Visual: dim the source bytecode rect to reflect "it's now in RAM" state
+        const src = (imp.label === 'font') ? flashA : document.getElementById('romfs-flash-b');
+        if (src) src.style.opacity = '0.3';
+      }
+    }
+    runAnim = requestAnimationFrame(step);
+  }
+
+  runBtn.addEventListener('click', runImport);
+  resetBtn.addEventListener('click', reset);
+  reset();
+}
+
+/* ===== Language Example Picker ===== */
+
+const LANG_EXAMPLES = {
+  startswith: {
+    note: 'In v1.25, str.startswith() and str.endswith() now accept a tuple of prefixes plus optional start/end positions -- matching CPython semantics.',
+    code: `# v1.25: tuple arg + start/end positions on startswith / endswith.
+filename = "image_2024_january.png"
+
+# Tuple of prefixes -- matches if any one matches
+print(filename.startswith(("image_", "video_", "doc_")))
+
+# start/end position bounds the match
+print(filename.startswith("2024", 6, 10))   # True -- '2024' starts at index 6
+print(filename.startswith("2024", 0, 5))    # False
+
+# endswith works the same way
+for ext in [".png", ".jpg", ".tiff"]:
+    print(f"{ext!r:8} -> {filename.endswith(ext)}")
+`
+  },
+  next2: {
+    note: '2-arg next(it, default) is now enabled on most ports in v1.25 -- returns the default instead of raising StopIteration.',
+    code: `# v1.25: next(iterator, default) is now enabled on most ports.
+def gen():
+    yield 1
+    yield 2
+
+it = gen()
+print(next(it))                # 1
+print(next(it))                # 2
+print(next(it, "exhausted"))   # "exhausted" -- no exception
+
+# Useful pattern: peek at the first match or fall back
+nums = [10, 20, 30, 40]
+first_big = next((n for n in nums if n > 25), None)
+print("first > 25:", first_big)
+`
+  },
+  vfsmount: {
+    note: 'v1.25: vfs.mount() with no arguments returns the table of currently-mounted filesystems. mpremote df uses this to give a much better mount summary.',
+    code: `# v1.25: vfs.mount() with no args returns the mount table.
+import vfs
+
+# In the PyScript build, the in-browser FS gets mounted at /
+# (the table will be small but real)
+mounts = vfs.mount()
+print("Mount table:", mounts)
+print("Number of mounts:", len(mounts))
+for entry in mounts:
+    print("  -", entry)
+`
+  },
+  funccode: {
+    note: 'v1.25 enables function.__code__ (and a function() constructor) on most ports. Combined with the marshal module (not in this build), they let you serialise functions.',
+    code: `# v1.25: function.__code__ and function() constructor.
+def squared(x):
+    return x * x
+
+# Get the code object underlying a function
+code = squared.__code__
+print("type:", type(code).__name__)
+print("co_name:", code.co_name)
+print("co_argcount:", code.co_argcount)
+
+# Reconstruct a callable by passing a code object to function()
+# (this is the building block that marshal.loads() uses for functions)
+new_squared = type(squared)(code, {})
+print("new_squared(7) =", new_squared(7))   # 49
+`
+  },
+  implbuild: {
+    note: 'New in v1.25: sys.implementation._build records the build name (board profile / variant). Useful for portable code that wants to detect the exact firmware variant.',
+    code: `# v1.25: sys.implementation._build is the build name (e.g. variant).
+import sys
+
+impl = sys.implementation
+print("name:    ", impl.name)
+print("version: ", impl.version)
+print("_build:  ", getattr(impl, "_build", "<not set>"))
+print("mpy:     ", getattr(impl, "_mpy", "<not set>"))
+
+# In a real firmware on, say, a PYBD-SF6, _build would be "PYBD_SF6".
+# In the PyScript build it's whatever variant string the wasm build was tagged with.
+`
+  },
+};
+
+function initLanguagePicker() {
+  const picker = document.getElementById('lang-picker');
+  const editor = document.getElementById('lang-editor');
+  const note = document.getElementById('lang-note');
+  const reset = document.getElementById('lang-reset');
+  if (!picker || !editor) return;
+
+  function load(key) {
+    const ex = LANG_EXAMPLES[key];
+    if (!ex) return;
+    editor.value = ex.code;
+    note.textContent = ex.note;
+  }
+  picker.addEventListener('change', () => load(picker.value));
+  reset.addEventListener('click', () => load(picker.value));
+  load(picker.value);
+}

--- a/micropython-v1.26/index.html
+++ b/micropython-v1.26/index.html
@@ -1,0 +1,643 @@
+---
+layout: release-notes
+title: MicroPython v1.26.0 Release Notes
+version: v1.26.0
+pyscript: true
+page_css: /micropython-v1.26/v1.26.css
+page_js: /micropython-v1.26/v1.26.js
+
+hero:
+  version: "v1.26"
+  tagline: "machine.I2CTarget, the float-accuracy overhaul, native emitter wins, plus STM32N6 and ESP32-C2."
+  date: "August 9, 2025"
+
+summary_cards:
+  - { icon: "&#128268;", title: "machine.I2CTarget", desc: "Python responds on I2C", target: "i2ctarget" }
+  - { icon: "&#127919;", title: "Float accuracy",   desc: "98.5% repr-reversibility", target: "floats" }
+  - { icon: "&#9889;",   title: "Native emitter",   desc: "Tighter code on every arch", target: "native" }
+  - { icon: "&#128640;", title: "Counter / Encoder", desc: "Hardware pulse counting", target: "counter" }
+
+stats:
+  - { value: 46, label: "Contributors" }
+  - { value: 13, label: "Timezones" }
+  - { value: 10, label: "New Boards" }
+
+mpy_banner:
+  headline: "Float and language demos on this page run real MicroPython in your browser."
+  body: "MicroPython is compiled to WebAssembly via PyScript and executes live as the page loads &mdash; no server required."
+
+toc:
+  - { id: "i2ctarget", label: "machine.I2CTarget" }
+  - { id: "floats",    label: "Float Accuracy" }
+  - { id: "native",    label: "Native Emitter" }
+  - { id: "counter",   label: "Counter / Encoder" }
+  - { id: "language",  label: "Language Tweaks" }
+  - { id: "n6c2",      label: "STM32N6 + ESP32-C2" }
+  - { id: "highlights", label: "Highlights" }
+
+boards:
+  summary: "10 new board definitions across 4 ports."
+  groups:
+    - port: "esp32"
+      boards: ["GARATRONIC_PYBSTICK26_ESP32C3", "SPARKFUN_IOT_REDBOARD_ESP32"]
+    - port: "samd"
+      boards: ["SPARKFUN_REDBOARD_TURBO", "SPARKFUN_SAMD21_DEV_BREAKOUT"]
+    - port: "stm32"
+      boards: ["NUCLEO_N657X0", "OPENMV_N6"]
+    - port: "zephyr"
+      boards: ["beagleplay_cc1352p7", "nrf5340dk", "nrf9151dk", "rpi_pico"]
+
+numbers:
+  summary: "v1.26 in numbers. esp32 grew most, driven by ESP-IDF v5.4.2 plus the new I2CTarget."
+  cards:
+    - { value: 46, label: "Contributors" }
+    - { value: 13, label: "Timezones" }
+    - { value: 10, label: "New Boards" }
+  code_size:
+    title: "Code size delta vs v1.25 (.text section, bytes)"
+    rows:
+      - { port: "esp32",      delta_bytes: 19064, bar_pct: 100, tooltip: "+1.12% &mdash; IDF 5.4.2 + I2CTarget" }
+      - { port: "stm32",      delta_bytes: 3776,  bar_pct: 20,  tooltip: "+0.97% &mdash; I2CTarget, float accuracy, native emitter" }
+      - { port: "mimxrt",     delta_bytes: 3600,  bar_pct: 19,  tooltip: "+0.97% &mdash; I2CTarget, float accuracy" }
+      - { port: "esp8266",    delta_bytes: 3484,  bar_pct: 18,  tooltip: "+0.50% &mdash; LX3 opcodes, LittleFS v2.11" }
+      - { port: "samd",       delta_bytes: 3296,  bar_pct: 17,  tooltip: "+1.23% &mdash; I2CTarget, float accuracy" }
+      - { port: "rp2 (PICO_W)", delta_bytes: 2252, bar_pct: 12, tooltip: "+0.25% &mdash; I2CTarget + DTLS Anti Replay" }
+      - { port: "renesas-ra", delta_bytes: 1296,  bar_pct: 7,   tooltip: "+0.21% &mdash; float accuracy, native emitter" }
+      - { port: "nrf",        delta_bytes: 1140,  bar_pct: 6,   tooltip: "+0.61% &mdash; float accuracy, IOBase" }
+      - { port: "rp2 (PICO)", delta_bytes: 556,   bar_pct: 3,   tooltip: "+0.25% &mdash; offset by -3kB compressed errors" }
+      - { port: "cc3200",     delta_bytes: 392,   bar_pct: 2,   tooltip: "+0.21% &mdash; IOBase at core feature level" }
+      - { port: "unix x64",   delta_bytes: -376,  bar_pct: 2,   tooltip: "-0.05% &mdash; bss reduction (was: DTLS additions)" }
+      - { port: "minimal x86", delta_bytes: -207, bar_pct: 1,   tooltip: "-0.11% &mdash; integer var-arg handling" }
+      - { port: "bare-arm",   delta_bytes: -96,   bar_pct: 1,   tooltip: "-0.17% &mdash; integer var-arg handling" }
+  contributors: |
+    Alessandro Gatti, Andrea Giammarchi, Andrew Leech, Angus Gratton, Anson Mansfield,
+    Anton Blanchard, Ayush Singh, Chris Webb, Christian Lang, Damien George,
+    Daniel Campora, Dani&euml;l van de Giessen, David Schneider, David Yang, Detlev Zundel,
+    Dryw Wade, dubiousjim, Elvis Pfutzenreuter, ennyKey, Garatronic, Herwin Grobben,
+    iabdalkader, IhorNehrutsa, Jeff Epler, Jim Mussared, Jonathan Hogg, Jos Verlinde,
+    Koudai Aono, Malcolm McKellips, Matt Trentini, Maureen Helm, Meir Armon,
+    Patrick Joy, Peter Harper, Phil Howard, purewack, Rick Sorensen, robert-hh, root,
+    SiZiOUS, stijn, TianShuang Ke, Vdragon, Yanfeng Liu, Yoctopuce dev, Yuuki NAGAO.
+
+pyscript_block: |
+  from pyscript import document, when
+  import sys
+
+  def run_editor(code_id, out_id):
+      code = document.querySelector("#" + code_id).value
+      out_el = document.querySelector("#" + out_id)
+      out_el.classList.remove("has-error")
+      lines = []
+      def _print(*args, sep=" ", end="\n"):
+          lines.append(sep.join(str(a) for a in args) + end)
+      try:
+          exec(code, {"print": _print})
+          output = "".join(lines) or "(no output)"
+      except Exception as e:
+          output = type(e).__name__ + ": " + str(e)
+          out_el.classList.add("has-error")
+      out_el.innerText = output
+
+  @when("click", "#float-run")
+  def _r_float(ev):
+      run_editor("float-editor", "float-output")
+
+  @when("click", "#lang-run")
+  def _r_lang(ev):
+      run_editor("lang-editor", "lang-output")
+
+  for s in document.querySelectorAll(".mpy-status"):
+      s.innerText = f"MicroPython {sys.version} ready"
+
+  # Auto-run the float demo so visitors see output immediately
+  run_editor("float-editor", "float-output")
+---
+
+<!-- ===== SECTION: I2CTarget ===== -->
+<section class="section" id="i2ctarget">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>machine.I2CTarget &mdash; Your MCU Answers, Not Just Asks</h2>
+    <p class="section-desc">
+      MicroPython has supported I2C as a controller for years. v1.26 inverts the relationship:
+      <strong>your MicroPython board can now <em>be</em> an I2C device</strong>, responding to
+      reads and writes from another controller. Bind a <code>bytearray</code> as a register
+      file for the simple case, or hook into IRQ callbacks to implement arbitrary protocols.
+    </p>
+  </div>
+
+  <!-- Bespoke I2C bus demo -->
+  <div class="demo-container">
+    <div class="demo-label">Interactive Demo &mdash; I2C Target on a Bus</div>
+
+    <div class="i2c-mode-toggle">
+      <button class="active" data-mode="buffer">Buffer mode</button>
+      <button data-mode="irq">IRQ mode</button>
+    </div>
+
+    <div class="i2c-stage">
+      <svg class="i2c-bus-svg" viewBox="0 0 600 200" preserveAspectRatio="xMidYMid meet">
+        <!-- Bus lines (SDA/SCL) -->
+        <line x1="120" y1="80"  x2="480" y2="80"  class="i2c-bus-line"/>
+        <line x1="120" y1="100" x2="480" y2="100" class="i2c-bus-line"/>
+        <text x="100" y="84"  class="i2c-bus-label">SDA</text>
+        <text x="100" y="104" class="i2c-bus-label">SCL</text>
+
+        <!-- Controller (left) -->
+        <rect x="20"  y="40" width="100" height="100" class="i2c-mcu controller-mcu"/>
+        <text x="70"  y="80" class="i2c-mcu-label">Host</text>
+        <text x="70"  y="100" class="i2c-mcu-sublabel">(controller)</text>
+        <text x="70"  y="120" class="i2c-mcu-port">I2C(0)</text>
+
+        <!-- Target (right) -->
+        <rect x="480" y="40" width="100" height="100" class="i2c-mcu target-mcu"/>
+        <text x="530" y="80"  class="i2c-mcu-label">MicroPython</text>
+        <text x="530" y="100" class="i2c-mcu-sublabel">(target, addr 0x10)</text>
+        <text x="530" y="120" class="i2c-mcu-port">I2CTarget(0)</text>
+
+        <!-- Animated packet -->
+        <g id="i2c-packet" style="display:none;">
+          <rect x="0" y="-12" width="40" height="24" class="i2c-packet-rect"/>
+          <text x="20" y="4" class="i2c-packet-label" id="i2c-packet-label">W 0x42</text>
+        </g>
+      </svg>
+
+      <div class="i2c-bytearray">
+        <div class="i2c-bytearray-label">Target memory: <code>buf = bytearray(16)</code></div>
+        <div class="i2c-bytearray-grid" id="i2c-bytearray-grid">
+          <!-- Cells injected by JS -->
+        </div>
+      </div>
+    </div>
+
+    <div class="i2c-controls">
+      <label>Register
+        <input type="number" id="i2c-reg" min="0" max="15" value="5" />
+      </label>
+      <label>Value (hex)
+        <input type="text" id="i2c-val" value="0x42" />
+      </label>
+      <button class="btn btn-primary" id="i2c-write-btn">Write</button>
+      <button class="btn btn-secondary" id="i2c-read-btn">Read</button>
+      <button class="btn btn-secondary" id="i2c-reset-btn">Reset</button>
+    </div>
+
+    <div class="i2c-log" id="i2c-log"></div>
+
+    <div class="i2c-irq-pane" id="i2c-irq-pane" style="display:none;">
+      <div class="i2c-irq-label">IRQ events fired on the target</div>
+      <div class="i2c-irq-list" id="i2c-irq-list"></div>
+    </div>
+  </div>
+
+  <!-- Code panel -->
+  <div class="code-block">
+    <div class="code-header">
+      <span>main.py &mdash; on the target board</span>
+      <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+    </div>
+<pre><span class="kw">from</span> machine <span class="kw">import</span> Pin, I2CTarget
+
+<span class="cmt"># Buffer mode &mdash; an I2C register/memory device backed by a bytearray</span>
+buf = <span class="bi">bytearray</span>(<span class="num">16</span>)
+target = I2CTarget(<span class="num">0</span>, scl=Pin(<span class="num">1</span>), sda=Pin(<span class="num">0</span>),
+                   addr=<span class="num">0x10</span>, mem=buf)
+
+<span class="cmt"># A controller on another board can now read/write this bytearray over I2C:</span>
+<span class="cmt">#   i2c.writeto_mem(0x10, 0x05, b'\x42')   -&gt; buf[5] becomes 0x42</span>
+<span class="cmt">#   i2c.readfrom_mem(0x10, 0x05, 1)        -&gt; b'\x42'</span></pre>
+  </div>
+
+  <h3 style="font-size:18px; margin-top:24px; margin-bottom:12px;">I2CTarget Port Support</h3>
+  <p style="font-size:14px; color:var(--text-secondary); margin-bottom:12px;">
+    All ports gaining <code style="background:var(--bg-tertiary); padding:2px 6px; border-radius:3px; font-size:12px;">machine.I2CTarget</code> in v1.26.
+  </p>
+  <div class="port-matrix">
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> alif</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> esp32</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> mimxrt</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> rp2</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> samd</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> stm32</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> zephyr</div>
+  </div>
+</section>
+
+<!-- ===== SECTION: FLOAT ACCURACY ===== -->
+<section class="section" id="floats">
+  <div class="section-header">
+    <span class="section-badge improved">Improved</span>
+    <h2>Float Accuracy &mdash; <code>repr</code> Round-Trips for Real</h2>
+    <p class="section-desc">
+      Before v1.26, only ~28% of single-precision floats round-tripped correctly through
+      <code>repr</code> &rarr; <code>float</code> &rarr; original value. v1.26 rewrites
+      float printing and formatting; that number is now <strong>98.5%</strong>. Double
+      precision improved from 38% to <strong>99.8%</strong>. The same fix means floats
+      survive a save/load cycle through <code>.mpy</code> files.
+    </p>
+  </div>
+
+  <div class="float-bars">
+    <div class="float-bar-row">
+      <div class="float-bar-label">Single precision</div>
+      <div class="float-bar-pair">
+        <div class="float-bar-strip">
+          <div class="float-bar-track"><div class="float-bar-fill" data-target="28" style="background: var(--accent-orange);"></div></div>
+          <div class="float-bar-tag">v1.25 &mdash; <span class="float-bar-num" data-target="28">0</span>%</div>
+        </div>
+        <div class="float-bar-strip">
+          <div class="float-bar-track"><div class="float-bar-fill" data-target="98.5" style="background: var(--accent-green);"></div></div>
+          <div class="float-bar-tag">v1.26 &mdash; <span class="float-bar-num" data-target="98.5">0</span>%</div>
+        </div>
+      </div>
+    </div>
+    <div class="float-bar-row">
+      <div class="float-bar-label">Double precision</div>
+      <div class="float-bar-pair">
+        <div class="float-bar-strip">
+          <div class="float-bar-track"><div class="float-bar-fill" data-target="38" style="background: var(--accent-orange);"></div></div>
+          <div class="float-bar-tag">v1.25 &mdash; <span class="float-bar-num" data-target="38">0</span>%</div>
+        </div>
+        <div class="float-bar-strip">
+          <div class="float-bar-track"><div class="float-bar-fill" data-target="99.8" style="background: var(--accent-green);"></div></div>
+          <div class="float-bar-tag">v1.26 &mdash; <span class="float-bar-num" data-target="99.8">0</span>%</div>
+        </div>
+      </div>
+    </div>
+    <p class="float-bars-caption">
+      Percentage of randomly-generated floats whose <code>repr(x)</code> output, when
+      passed back through <code>float()</code>, recovers the original value exactly.
+    </p>
+  </div>
+
+  <div class="demo-container live-playground">
+    <div class="demo-label">
+      Live demo
+      <span class="pyscript-tag">PyScript</span>
+    </div>
+    <p class="playground-intro">
+      Edit and run real MicroPython below. The output you see is generated by the same
+      improved float-printing routines that ship in v1.26.
+    </p>
+    <textarea class="mpy-code-editor" id="float-editor" spellcheck="false"># Try a tricky float &mdash; this is real MicroPython running in your browser.
+x = 0.1 + 0.2
+print(repr(x))                  # 0.30000000000000004
+print(float(repr(x)) == x)      # True &mdash; repr round-trips
+
+# Some classic offenders, including denormals and near-overflow values:
+for v in [1/3, 1e-300, 2**-1074, 1.5e308, 22/7]:
+    s = repr(v)
+    print("{:30}  -&gt;  {:30}  round-trips: {}".format(repr(v), repr(s), float(s) == v))
+</textarea>
+    <div class="mpy-btn-row">
+      <button class="mpy-run-btn" id="float-run">Run &#9654;</button>
+      <span class="mpy-status">Loading MicroPython&hellip;</span>
+    </div>
+    <div class="mpy-output" id="float-output"></div>
+    <p class="playground-note">
+      v1.26 also folds float constants at compile time: <code>const(2 * math.pi)</code>
+      now evaluates in the compiler, not at runtime. And in object representation C
+      (where floats are stored within the immediate object value, losing the bottom
+      two bits), a heuristic now reconstructs those bits to reduce the bias toward zero.
+    </p>
+  </div>
+</section>
+
+<!-- ===== SECTION: NATIVE EMITTER ===== -->
+<section class="section" id="native">
+  <div class="section-header">
+    <span class="section-badge improved">Improved</span>
+    <h2>Native &amp; Viper Emitters &mdash; Every Architecture Got a Tune-Up</h2>
+    <p class="section-desc">
+      The native code emitters now produce more compact loads and stores across
+      <strong>ARM, Thumb, Xtensa, RISC-V 32, x86 and x64</strong>. Thumb&nbsp;v1
+      (RP2040) gains long jumps greater than 12 bits, allowing larger Python functions
+      to compile native. The inline Xtensa assembler now implements most of the LX3
+      opcode set.
+    </p>
+  </div>
+
+  <div class="port-matrix">
+    <div class="port-chip"><span class="check">&#10003;</span> ARM</div>
+    <div class="port-chip"><span class="check">&#10003;</span> Thumb</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> Thumb v1 / RP2040</div>
+    <div class="port-chip"><span class="check">&#10003;</span> Xtensa</div>
+    <div class="port-chip"><span class="check">&#10003;</span> RISC-V 32</div>
+    <div class="port-chip"><span class="check">&#10003;</span> x86</div>
+    <div class="port-chip"><span class="check">&#10003;</span> x64</div>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">Long jumps on Thumb v1</div>
+    Larger functions decorated with <code>@micropython.native</code> now compile on
+    RP2040 boards that previously hit branch-range limits. Inline Xtensa
+    (<code>@micropython.asm_xtensa</code>) gains <code>addx2</code>, <code>subx2</code>,
+    <code>ssl</code>, <code>ssr</code>, and most other LX3 opcodes &mdash; bringing the
+    inline assembler much closer to feature-parity with hand-written ESP32 firmware.
+  </div>
+</section>
+
+<!-- ===== SECTION: COUNTER / ENCODER ===== -->
+<section class="section" id="counter">
+  <div class="section-header">
+    <span class="section-badge new">New &mdash; esp32 only</span>
+    <h2>machine.Counter &amp; machine.Encoder &mdash; Hardware Pulse Counting</h2>
+    <p class="section-desc">
+      A new <code>esp32.PCNT</code> class wraps the ESP32 hardware pulse-counter
+      peripheral, and ships with cross-port-style APIs <code>machine.Counter</code>
+      (single-channel) and <code>machine.Encoder</code> (quadrature). Drag the dial
+      below to feel how a quadrature encoder works.
+    </p>
+  </div>
+
+  <div class="demo-container">
+    <div class="demo-label">Interactive Demo &mdash; Quadrature Encoder</div>
+
+    <div class="encoder-mode-toggle">
+      <button class="active" data-mode="encoder">Encoder (quadrature)</button>
+      <button data-mode="counter">Counter (single channel)</button>
+    </div>
+
+    <div class="encoder-stage">
+      <div class="encoder-dial-wrap">
+        <svg class="encoder-dial" viewBox="0 0 200 200" id="encoder-dial">
+          <circle cx="100" cy="100" r="85" class="encoder-dial-bg"/>
+          <g id="encoder-tick-group">
+            <line x1="100" y1="20" x2="100" y2="35" class="encoder-tick"/>
+          </g>
+          <circle cx="100" cy="100" r="6" class="encoder-hub"/>
+        </svg>
+        <p class="encoder-help">Drag the dial to rotate</p>
+      </div>
+
+      <div class="encoder-readout">
+        <div class="encoder-count-card">
+          <div class="encoder-count-label">count</div>
+          <div class="encoder-count-value" id="encoder-count">0</div>
+        </div>
+        <div class="encoder-direction-card">
+          <div class="encoder-direction-label">direction</div>
+          <div class="encoder-direction-value" id="encoder-direction">&middot;</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="encoder-traces">
+      <div class="encoder-trace-row">
+        <span class="encoder-trace-label">Channel A</span>
+        <canvas id="encoder-trace-a" height="50"></canvas>
+      </div>
+      <div class="encoder-trace-row" id="encoder-trace-b-row">
+        <span class="encoder-trace-label">Channel B</span>
+        <canvas id="encoder-trace-b" height="50"></canvas>
+      </div>
+    </div>
+
+    <div class="code-block" style="margin-top:16px;">
+      <div class="code-header">
+        <span>main.py</span>
+        <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+      </div>
+<pre><span class="kw">from</span> machine <span class="kw">import</span> Pin, Encoder
+
+enc = Encoder(<span class="num">0</span>, phase_a=Pin(<span class="num">4</span>), phase_b=Pin(<span class="num">5</span>))
+<span class="kw">while</span> <span class="bi">True</span>:
+    <span class="bi">print</span>(enc.value())   <span class="cmt"># signed count, sign indicates direction</span></pre>
+    </div>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">esp32 only in v1.26</div>
+    The <code>Counter</code> and <code>Encoder</code> classes live under
+    <code>machine.*</code> but are currently implemented only on the esp32 port
+    (via <code>esp32.PCNT</code>). The same pattern &mdash; introducing a feature on one
+    port and standardising it across all of them later &mdash; is exactly what v1.28 did
+    with <code>machine.PWM</code> and <code>machine.CAN</code>.
+  </div>
+</section>
+
+<!-- ===== SECTION: LANGUAGE TWEAKS ===== -->
+<section class="section" id="language">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>Python Language Tweaks</h2>
+    <p class="section-desc">
+      Five small core-language additions in v1.26. Pick one from the dropdown to load
+      the example into the editor, then run it live.
+    </p>
+  </div>
+
+  <div class="demo-container live-playground">
+    <div class="demo-label">
+      Live demo
+      <span class="pyscript-tag">PyScript</span>
+    </div>
+
+    <div class="example-picker-row">
+      <label for="lang-picker">Example:</label>
+      <select id="lang-picker" class="example-picker">
+        <option value="all">__all__ in star imports</option>
+        <option value="setname">PEP 487 __set_name__</option>
+        <option value="format">str.format digit grouping</option>
+        <option value="array">array() from any iterable</option>
+        <option value="slice">slice on stack (heap_lock)</option>
+      </select>
+    </div>
+
+    <textarea class="mpy-code-editor" id="lang-editor" spellcheck="false"></textarea>
+    <div class="mpy-btn-row">
+      <button class="mpy-run-btn" id="lang-run">Run &#9654;</button>
+      <button class="mpy-clear-btn" id="lang-reset">Reset example</button>
+      <span class="mpy-status">Loading MicroPython&hellip;</span>
+    </div>
+    <div class="mpy-output" id="lang-output"></div>
+
+    <p class="playground-note" id="lang-note"></p>
+  </div>
+</section>
+
+<!-- ===== SECTION: STM32N6 + ESP32-C2 ===== -->
+<section class="section" id="n6c2">
+  <div class="section-header">
+    <span class="section-badge new">New MCUs</span>
+    <h2>STM32N6 &amp; ESP32-C2</h2>
+    <p class="section-desc">
+      Two new microcontrollers added in v1.26 &mdash; one chasing high-end ML inference
+      on the edge, the other chasing low-cost RISC-V wireless.
+    </p>
+  </div>
+
+  <div class="mcu-spec-cards">
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>STM32N6</h3>
+        <span class="badge active">800 MHz</span>
+      </div>
+      <div class="mcu-spec-strip">
+        <div><span class="mcu-spec-num">800</span> MHz</div>
+        <div><span class="mcu-spec-num">ML</span> accel</div>
+        <div><span class="mcu-spec-num">XSPI</span> XIP flash</div>
+      </div>
+      <p class="mcu-spec-desc">
+        STMicroelectronics' new high-performance MCU with built-in machine-learning
+        accelerators. v1.26 supports USB, XSPI memory-mapped external flash, a
+        filesystem, basic peripherals and deep sleep.
+      </p>
+      <div class="mcu-spec-boards">
+        <span class="board-chip">NUCLEO_N657X0</span>
+        <span class="board-chip">OPENMV_N6</span>
+      </div>
+    </div>
+
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>ESP32-C2 (ESP8684)</h3>
+        <span class="badge active">RISC-V</span>
+      </div>
+      <div class="mcu-spec-strip">
+        <div><span class="mcu-spec-num">RV32</span> core</div>
+        <div><span class="mcu-spec-num">WiFi</span> + BLE</div>
+        <div><span class="mcu-spec-num">low</span> cost</div>
+      </div>
+      <p class="mcu-spec-desc">
+        Espressif's small, low-cost RISC-V MCU with WiFi and BLE. MicroPython on the
+        C2 supports a REPL, filesystem, GPIO, I2C, ADC, PWM, timers, WiFi and BLE.
+      </p>
+      <div class="mcu-spec-boards">
+        <span class="board-chip">ESP32_GENERIC_C2 / FLASH_2M</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== SECTION: HIGHLIGHTS ===== -->
+<section class="section" id="highlights">
+  <div class="section-header">
+    <h2>Highlights</h2>
+    <p class="section-desc">Other notable improvements in v1.26.</p>
+  </div>
+
+  <div class="highlights-grid">
+    <div class="highlight-card">
+      <span class="hl-icon">&#128274;</span>
+      <h3>DTLS server support</h3>
+      <p>The mbedTLS backend now handles HelloVerify and Anti Replay protection,
+        enabling proper DTLS servers.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">tls</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128231;</span>
+      <h3>lwIP UDP queue</h3>
+      <p>Multiple incoming UDP and raw packets can now be queued, replacing the previous
+        single-packet buffer. More robust UDP protocols.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">lwIP</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128196;</span>
+      <h3>framebuf ROM blits</h3>
+      <p><code>FrameBuffer.blit()</code> now accepts read-only data, so custom fonts and
+        bitmaps can live in flash instead of RAM.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">framebuf</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#9202;</span>
+      <h3>time module range standardised</h3>
+      <p><code>time()</code>, <code>localtime()</code> and <code>mktime()</code> now
+        cover at least 1970&ndash;2099 on every platform, regardless of the underlying
+        epoch.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">all ports</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128202;</span>
+      <h3>VM avoids slice allocations</h3>
+      <p><code>buf[a:b] = c</code> on bytearrays/memoryviews no longer heap-allocates
+        the slice &mdash; works inside hard IRQs and reduces GC churn.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">core</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128270;</span>
+      <h3>mpremote fs tree</h3>
+      <p>New <code>mpremote fs tree</code> command (with <code>-s</code>/<code>-h</code>
+        for sizes), and <code>df</code> now uses no-arg <code>vfs.mount()</code> for a
+        much better mount summary.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">mpremote</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128737;</span>
+      <h3>Compressed error messages on rp2</h3>
+      <p>Enabled by default, saving ~3&nbsp;kB of firmware on RP2040 / RP2350 builds.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">rp2</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#129690;</span>
+      <h3>sys.implementation._thread</h3>
+      <p>New attribute reports the threading model in use &mdash; either GIL or
+        unsafe/no-GIL &mdash; so portable code can adapt.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">sys</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#9888;</span>
+      <h3>nrf <code>enable_irq()</code> &mdash; breaking change</h3>
+      <p>Signature is now <code>enable_irq(state)</code> matching all other ports.
+        Previously <code>enable_irq()</code>. Affects nrf boards only.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">nrf</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128300;</span>
+      <h3>Zephyr v4.0.0 + new peripherals</h3>
+      <p>PWM support added; UARTs gain ring-buffered IRQ-driven I/O; SoftI2C/SoftSPI
+        enabled; <code>boot.py</code>/<code>main.py</code> now run at startup.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">zephyr</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127760;</span>
+      <h3>WebAssembly FFI improvements</h3>
+      <p><code>JsProxy</code> equality, better <code>has</code>/<code>get</code>
+        proxying, correct self-binding for JavaScript methods, and reuse of proxy
+        references for stable identity on the Python side.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">webassembly</span>
+      </div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128221;</span>
+      <h3>__all__ in star imports</h3>
+      <p><code>from mod import *</code> now respects a module-level
+        <code>__all__</code>. PEP 487 <code>__set_name__</code> is also supported.</p>
+      <div class="hl-ports">
+        <span class="hl-port-tag">core</span>
+      </div>
+    </div>
+  </div>
+</section>

--- a/micropython-v1.26/v1.26.css
+++ b/micropython-v1.26/v1.26.css
@@ -1,0 +1,517 @@
+/* ============================================================
+   v1.26 page-specific styles
+   I2CTarget bus + bytearray, float-accuracy bars, quadrature
+   encoder dial + traces, language example picker, MCU spec cards.
+   ============================================================ */
+
+/* ===== I2CTarget Demo ===== */
+.i2c-mode-toggle {
+  display: inline-flex;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 3px;
+  margin-bottom: 20px;
+}
+.i2c-mode-toggle button {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+.i2c-mode-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.i2c-stage {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.i2c-bus-svg {
+  width: 100%;
+  height: 200px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.i2c-bus-line {
+  stroke: var(--text-muted);
+  stroke-width: 2;
+}
+.i2c-bus-label {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-anchor: end;
+}
+
+.i2c-mcu {
+  fill: var(--bg-tertiary);
+  stroke: var(--border);
+  stroke-width: 2;
+  rx: 6;
+}
+.i2c-mcu.target-mcu {
+  stroke: var(--accent-green);
+}
+.i2c-mcu-label {
+  fill: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+.i2c-mcu-sublabel {
+  fill: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  text-anchor: middle;
+}
+.i2c-mcu-port {
+  fill: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-anchor: middle;
+}
+
+.i2c-packet-rect {
+  fill: var(--accent);
+  rx: 4;
+}
+.i2c-packet-rect.read {
+  fill: var(--accent-green);
+}
+.i2c-packet-label {
+  fill: #fff;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.i2c-bytearray {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+.i2c-bytearray-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  font-family: var(--font-mono);
+}
+.i2c-bytearray-grid {
+  display: grid;
+  grid-template-columns: repeat(16, 1fr);
+  gap: 4px;
+}
+.i2c-cell {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 0;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  position: relative;
+  transition: all 0.3s ease;
+}
+.i2c-cell .i2c-cell-idx {
+  font-size: 9px;
+  color: var(--text-muted);
+  display: block;
+  margin-bottom: 2px;
+}
+.i2c-cell .i2c-cell-val {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.i2c-cell.recently-written {
+  background: var(--accent-green-glow);
+  border-color: var(--accent-green);
+  transform: scale(1.05);
+}
+.i2c-cell.recently-read {
+  background: var(--accent-glow);
+  border-color: var(--accent);
+}
+
+.i2c-controls {
+  display: flex;
+  gap: 12px;
+  align-items: end;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.i2c-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  gap: 4px;
+}
+.i2c-controls input {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  width: 100px;
+}
+.i2c-controls input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.i2c-log {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  max-height: 100px;
+  overflow-y: auto;
+  color: var(--text-secondary);
+  min-height: 40px;
+}
+.i2c-log .log-write { color: var(--accent); }
+.i2c-log .log-read  { color: var(--accent-green); }
+.i2c-log .log-empty { color: var(--text-muted); font-style: italic; }
+
+.i2c-irq-pane {
+  background: var(--bg-code);
+  border: 1px solid var(--accent-orange);
+  border-radius: 6px;
+  padding: 12px;
+  margin-top: 12px;
+}
+.i2c-irq-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--accent-orange);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.i2c-irq-list {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  min-height: 40px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+.i2c-irq-event {
+  padding: 2px 0;
+  animation: irq-flash 1.6s ease-out;
+}
+@keyframes irq-flash {
+  0%   { background: var(--accent-orange); color: #fff; }
+  100% { background: transparent; color: var(--text-secondary); }
+}
+
+/* ===== Float Accuracy Bars ===== */
+.float-bars {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  margin: 24px 0;
+}
+.float-bar-row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.float-bar-row:last-of-type { margin-bottom: 0; }
+.float-bar-label {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.float-bar-pair {
+  display: grid;
+  gap: 8px;
+}
+.float-bar-strip {
+  display: grid;
+  grid-template-columns: 1fr 140px;
+  align-items: center;
+  gap: 12px;
+}
+.float-bar-track {
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  height: 16px;
+  overflow: hidden;
+  position: relative;
+}
+.float-bar-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 6px;
+  transition: width 1.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.float-bar-tag {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.float-bar-num {
+  color: var(--text-primary);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.float-bars-caption {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 16px;
+  font-style: italic;
+}
+
+/* ===== Encoder Demo ===== */
+.encoder-mode-toggle {
+  display: inline-flex;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 3px;
+  margin-bottom: 20px;
+}
+.encoder-mode-toggle button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+.encoder-mode-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.encoder-stage {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.encoder-dial-wrap {
+  text-align: center;
+}
+.encoder-dial {
+  width: 200px;
+  height: 200px;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+.encoder-dial:active { cursor: grabbing; }
+.encoder-dial-bg {
+  fill: var(--bg-primary);
+  stroke: var(--border);
+  stroke-width: 2;
+}
+.encoder-tick {
+  stroke: var(--accent);
+  stroke-width: 4;
+  stroke-linecap: round;
+}
+.encoder-hub {
+  fill: var(--accent);
+}
+.encoder-help {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 8px;
+  font-style: italic;
+}
+
+.encoder-readout {
+  display: grid;
+  gap: 12px;
+}
+.encoder-count-card,
+.encoder-direction-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  text-align: center;
+}
+.encoder-count-label,
+.encoder-direction-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.encoder-count-value {
+  font-family: var(--font-mono);
+  font-size: 36px;
+  font-weight: 800;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+.encoder-direction-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--accent-green);
+}
+
+.encoder-traces {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: grid;
+  gap: 4px;
+}
+.encoder-trace-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  align-items: center;
+  gap: 12px;
+}
+.encoder-trace-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+.encoder-trace-row canvas {
+  width: 100%;
+  height: 50px;
+  display: block;
+}
+
+/* ===== Language Example Picker ===== */
+.example-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.example-picker-row label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+.example-picker {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  cursor: pointer;
+  flex: 1;
+  max-width: 360px;
+}
+.example-picker:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ===== MCU Spec Cards ===== */
+.mcu-spec-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+.mcu-spec-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  transition: all 0.2s ease;
+}
+.mcu-spec-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+.mcu-spec-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.mcu-spec-header h3 {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+.mcu-spec-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+.mcu-spec-strip > div {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.mcu-spec-num {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+.mcu-spec-desc {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.mcu-spec-boards {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ===== Responsive overrides ===== */
+@media (max-width: 768px) {
+  .encoder-stage { grid-template-columns: 1fr; justify-items: center; }
+  .float-bar-row { grid-template-columns: 1fr; }
+  .float-bar-strip { grid-template-columns: 1fr; }
+  .i2c-bytearray-grid { grid-template-columns: repeat(8, 1fr); }
+}

--- a/micropython-v1.26/v1.26.js
+++ b/micropython-v1.26/v1.26.js
@@ -1,0 +1,473 @@
+/* ============================================================
+   v1.26 page-specific behaviour
+   I2CTarget bus animation, float-accuracy bars, quadrature
+   encoder dial, language example picker.
+   ============================================================ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  initI2CTargetDemo();
+  initFloatBars();
+  initEncoderDemo();
+  initLanguagePicker();
+});
+
+/* ===== I2CTarget Demo ===== */
+
+function initI2CTargetDemo() {
+  const grid = document.getElementById('i2c-bytearray-grid');
+  if (!grid) return;
+
+  const buf = new Uint8Array(16);
+  const cells = [];
+  for (let i = 0; i < 16; i++) {
+    const cell = document.createElement('div');
+    cell.className = 'i2c-cell';
+    cell.innerHTML = `<span class="i2c-cell-idx">${i.toString(16).padStart(2, '0')}</span>` +
+                     `<span class="i2c-cell-val">00</span>`;
+    grid.appendChild(cell);
+    cells.push(cell);
+  }
+
+  const log = document.getElementById('i2c-log');
+  const irqList = document.getElementById('i2c-irq-list');
+  const irqPane = document.getElementById('i2c-irq-pane');
+  const regInput = document.getElementById('i2c-reg');
+  const valInput = document.getElementById('i2c-val');
+  const writeBtn = document.getElementById('i2c-write-btn');
+  const readBtn = document.getElementById('i2c-read-btn');
+  const resetBtn = document.getElementById('i2c-reset-btn');
+  const packet = document.getElementById('i2c-packet');
+  const packetLabel = document.getElementById('i2c-packet-label');
+  const modeButtons = document.querySelectorAll('.i2c-mode-toggle button');
+
+  let mode = 'buffer';
+  let packetAnim = null;
+
+  function setMode(next) {
+    mode = next;
+    modeButtons.forEach(b => b.classList.toggle('active', b.dataset.mode === next));
+    irqPane.style.display = next === 'irq' ? 'block' : 'none';
+  }
+  modeButtons.forEach(b => b.addEventListener('click', () => setMode(b.dataset.mode)));
+
+  function logEntry(html, cls) {
+    if (log.querySelector('.log-empty')) log.innerHTML = '';
+    const line = document.createElement('div');
+    line.className = cls;
+    line.innerHTML = html;
+    log.insertBefore(line, log.firstChild);
+    while (log.children.length > 6) log.removeChild(log.lastChild);
+  }
+
+  function irqEvent(name) {
+    if (mode !== 'irq') return;
+    if (irqList.querySelector('.log-empty')) irqList.innerHTML = '';
+    const line = document.createElement('div');
+    line.className = 'i2c-irq-event';
+    line.textContent = name;
+    irqList.insertBefore(line, irqList.firstChild);
+    while (irqList.children.length > 6) irqList.removeChild(irqList.lastChild);
+  }
+
+  function parseHexByte(s) {
+    s = s.trim();
+    if (s.startsWith('0x') || s.startsWith('0X')) s = s.slice(2);
+    const n = parseInt(s, 16);
+    if (Number.isNaN(n) || n < 0 || n > 255) return null;
+    return n;
+  }
+
+  function flashCell(idx, kind) {
+    const cell = cells[idx];
+    cell.classList.remove('recently-written', 'recently-read');
+    void cell.offsetWidth; // restart animation
+    cell.classList.add(kind === 'write' ? 'recently-written' : 'recently-read');
+    setTimeout(() => cell.classList.remove('recently-written', 'recently-read'), 1200);
+  }
+
+  function animatePacket(direction, label, isRead, onArrive) {
+    if (packetAnim) cancelAnimationFrame(packetAnim);
+    packetLabel.textContent = label;
+    packet.querySelector('rect').classList.toggle('read', isRead);
+    packet.style.display = '';
+
+    const startX = direction === 'forward' ? 130 : 470;
+    const endX   = direction === 'forward' ? 470 : 130;
+    const t0 = performance.now();
+    const duration = 700;
+
+    function step(t) {
+      const p = Math.min((t - t0) / duration, 1);
+      const ease = 1 - Math.pow(1 - p, 3);
+      const x = startX + (endX - startX) * ease;
+      packet.setAttribute('transform', `translate(${x}, 90)`);
+      if (p < 1) {
+        packetAnim = requestAnimationFrame(step);
+      } else {
+        packet.style.display = 'none';
+        if (onArrive) onArrive();
+      }
+    }
+    packetAnim = requestAnimationFrame(step);
+  }
+
+  function doWrite() {
+    const reg = parseInt(regInput.value, 10);
+    const val = parseHexByte(valInput.value);
+    if (Number.isNaN(reg) || reg < 0 || reg > 15 || val === null) {
+      logEntry('<span class="log-empty">Invalid register or value</span>', '');
+      return;
+    }
+    irqEvent(`I2CTarget.IRQ_WRITE_REQ  reg=0x${reg.toString(16).padStart(2,'0')}`);
+    animatePacket('forward', `W ${val.toString(16).padStart(2,'0').toUpperCase()}@${reg.toString(16).padStart(2,'0').toUpperCase()}`, false, () => {
+      buf[reg] = val;
+      cells[reg].querySelector('.i2c-cell-val').textContent = val.toString(16).padStart(2, '0').toUpperCase();
+      flashCell(reg, 'write');
+      logEntry(`<span class="log-write">i2c.writeto_mem(0x10, 0x${reg.toString(16).padStart(2,'0')}, b'\\x${val.toString(16).padStart(2,'0')}')</span>`, 'log-write');
+      irqEvent(`I2CTarget.IRQ_END  buf[${reg}] = 0x${val.toString(16).padStart(2,'0')}`);
+    });
+  }
+
+  function doRead() {
+    const reg = parseInt(regInput.value, 10);
+    if (Number.isNaN(reg) || reg < 0 || reg > 15) return;
+    irqEvent(`I2CTarget.IRQ_READ_REQ  reg=0x${reg.toString(16).padStart(2,'0')}`);
+    flashCell(reg, 'read');
+    const val = buf[reg];
+    animatePacket('backward', `R ${val.toString(16).padStart(2,'0').toUpperCase()}@${reg.toString(16).padStart(2,'0').toUpperCase()}`, true, () => {
+      logEntry(`<span class="log-read">i2c.readfrom_mem(0x10, 0x${reg.toString(16).padStart(2,'0')}, 1) -> b'\\x${val.toString(16).padStart(2,'0')}'</span>`, 'log-read');
+      irqEvent(`I2CTarget.IRQ_END`);
+    });
+  }
+
+  function doReset() {
+    for (let i = 0; i < 16; i++) {
+      buf[i] = 0;
+      cells[i].querySelector('.i2c-cell-val').textContent = '00';
+    }
+    log.innerHTML = '<span class="log-empty">Bus log cleared.</span>';
+    irqList.innerHTML = '<span class="log-empty">No IRQs yet.</span>';
+  }
+
+  writeBtn.addEventListener('click', doWrite);
+  readBtn.addEventListener('click', doRead);
+  resetBtn.addEventListener('click', doReset);
+
+  log.innerHTML = '<span class="log-empty">Press Write or Read to send a transaction.</span>';
+  irqList.innerHTML = '<span class="log-empty">Switch to IRQ mode to see IRQ events.</span>';
+}
+
+/* ===== Float Accuracy Bars ===== */
+
+function initFloatBars() {
+  const bars = document.querySelectorAll('.float-bar-fill');
+  const nums = document.querySelectorAll('.float-bar-num');
+  if (!bars.length) return;
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (!entry.isIntersecting) return;
+      bars.forEach(bar => {
+        const target = parseFloat(bar.dataset.target);
+        bar.style.width = target + '%';
+      });
+      nums.forEach(num => {
+        const target = parseFloat(num.dataset.target);
+        const start = performance.now();
+        const duration = 1200;
+        const isFloat = target % 1 !== 0;
+        function tick(t) {
+          const p = Math.min((t - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - p, 3);
+          const v = target * eased;
+          num.textContent = isFloat ? v.toFixed(1) : Math.round(v);
+          if (p < 1) requestAnimationFrame(tick);
+        }
+        requestAnimationFrame(tick);
+      });
+      observer.disconnect();
+    });
+  }, { threshold: 0.4 });
+
+  observer.observe(bars[0]);
+}
+
+/* ===== Encoder / Counter Demo ===== */
+
+function initEncoderDemo() {
+  const dial = document.getElementById('encoder-dial');
+  if (!dial) return;
+  const tickGroup = document.getElementById('encoder-tick-group');
+  const countEl = document.getElementById('encoder-count');
+  const dirEl = document.getElementById('encoder-direction');
+  const traceA = document.getElementById('encoder-trace-a');
+  const traceB = document.getElementById('encoder-trace-b');
+  const traceBRow = document.getElementById('encoder-trace-b-row');
+  const modeButtons = document.querySelectorAll('.encoder-mode-toggle button');
+
+  let angle = 0;        // in degrees, accumulated
+  let lastQuadState = 0; // 0..3
+  let count = 0;
+  let mode = 'encoder';
+  let dragging = false;
+  let lastPointerAngle = null;
+  // Trace history: array of {a:0/1, b:0/1, t}
+  const traces = [];
+  const TRACE_MAX = 80;
+
+  function setMode(next) {
+    mode = next;
+    modeButtons.forEach(b => b.classList.toggle('active', b.dataset.mode === next));
+    traceBRow.style.display = next === 'encoder' ? 'grid' : 'none';
+    redraw();
+  }
+  modeButtons.forEach(b => b.addEventListener('click', () => setMode(b.dataset.mode)));
+
+  function quadrature(deg) {
+    // Each 90 deg increments quadrature state by 1 (or wraps)
+    const step = ((deg % 360) + 360) % 360;
+    return Math.floor(step / 90) % 4;
+  }
+
+  function pointerAngle(evt) {
+    const rect = dial.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const x = evt.clientX - cx;
+    const y = evt.clientY - cy;
+    return Math.atan2(y, x) * 180 / Math.PI; // -180..180, 0 = right
+  }
+
+  function pushTraceSample() {
+    // a = high in quadrant 0,1 ; b = high in quadrant 1,2  -> 90 deg phase
+    const q = quadrature(angle);
+    const a = (q === 0 || q === 1) ? 1 : 0;
+    const b = (q === 1 || q === 2) ? 1 : 0;
+    traces.push({ a, b });
+    while (traces.length > TRACE_MAX) traces.shift();
+  }
+
+  function updateFromAngle(newAngle) {
+    const before = quadrature(angle);
+    angle = newAngle;
+    const after = quadrature(angle);
+    if (before !== after) {
+      const fwdNext = (before + 1) % 4;
+      const isForward = (after === fwdNext);
+      if (mode === 'encoder') {
+        count += isForward ? 1 : -1;
+        dirEl.textContent = isForward ? '↻' : '↺';
+        dirEl.style.color = isForward ? 'var(--accent-green)' : 'var(--accent-orange)';
+      } else {
+        // Counter mode: single-channel; direction-blind, every edge ticks up.
+        count += 1;
+        dirEl.textContent = '→';
+        dirEl.style.color = 'var(--accent-green)';
+      }
+      countEl.textContent = count;
+    }
+    pushTraceSample();
+    redraw();
+  }
+
+  function rotateTick() {
+    tickGroup.setAttribute('transform', `rotate(${angle} 100 100)`);
+  }
+
+  function drawTrace(canvas, key) {
+    const dpr = window.devicePixelRatio || 1;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    const ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, w, h);
+
+    const style = getComputedStyle(document.documentElement);
+    const lineColor = key === 'a'
+      ? style.getPropertyValue('--accent').trim()
+      : style.getPropertyValue('--accent-green').trim();
+    const gridColor = style.getPropertyValue('--border').trim();
+    const labelColor = style.getPropertyValue('--text-muted').trim();
+
+    const padding = 6;
+    const yHigh = padding + 4;
+    const yLow = h - padding - 4;
+
+    // Baseline grid
+    ctx.strokeStyle = gridColor;
+    ctx.lineWidth = 0.5;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(padding, yHigh); ctx.lineTo(w - padding, yHigh);
+    ctx.moveTo(padding, yLow); ctx.lineTo(w - padding, yLow);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    ctx.fillStyle = labelColor;
+    ctx.font = '9px monospace';
+    ctx.fillText('1', 2, yHigh + 3);
+    ctx.fillText('0', 2, yLow + 3);
+
+    if (traces.length === 0) return;
+
+    ctx.strokeStyle = lineColor;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    const stepX = (w - padding * 2) / (TRACE_MAX - 1);
+    let x = padding;
+    let lastY = traces[0][key] === 1 ? yHigh : yLow;
+    ctx.moveTo(x, lastY);
+    for (let i = 1; i < traces.length; i++) {
+      x = padding + i * stepX;
+      const y = traces[i][key] === 1 ? yHigh : yLow;
+      if (y !== lastY) {
+        ctx.lineTo(x, lastY);
+        ctx.lineTo(x, y);
+        lastY = y;
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+    ctx.stroke();
+  }
+
+  function redraw() {
+    rotateTick();
+    drawTrace(traceA, 'a');
+    if (mode === 'encoder') drawTrace(traceB, 'b');
+  }
+
+  // Pointer interaction
+  dial.addEventListener('pointerdown', (e) => {
+    dragging = true;
+    dial.setPointerCapture(e.pointerId);
+    lastPointerAngle = pointerAngle(e);
+  });
+  dial.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    const cur = pointerAngle(e);
+    let delta = cur - lastPointerAngle;
+    if (delta > 180) delta -= 360;
+    if (delta < -180) delta += 360;
+    lastPointerAngle = cur;
+    updateFromAngle(angle + delta);
+  });
+  dial.addEventListener('pointerup', () => { dragging = false; });
+  dial.addEventListener('pointercancel', () => { dragging = false; });
+
+  // Theme change redraws traces
+  document.addEventListener('themechange', redraw);
+  // Resize on window resize
+  window.addEventListener('resize', redraw);
+
+  // Seed traces with neutral state and draw once
+  for (let i = 0; i < TRACE_MAX; i++) traces.push({ a: 0, b: 0 });
+  redraw();
+}
+
+/* ===== Language Example Picker ===== */
+
+const LANG_EXAMPLES = {
+  all: {
+    note: 'In v1.26, MicroPython now respects a module-level __all__ when resolving names from `from x import *`.',
+    code: `# v1.26: __all__ is now respected by star imports.
+# Define a tiny in-memory module and import * from it.
+import sys
+
+class _M:
+    __all__ = ["wanted"]
+    wanted = "I'll show up in the star import"
+    hidden = "I'll stay private"
+
+sys.modules["mymod"] = _M
+
+# Now perform: from mymod import *
+ns = {}
+exec("from mymod import *", ns)
+print("wanted:", ns.get("wanted"))
+print("hidden:", ns.get("hidden", "<not exported>"))
+`
+  },
+  setname: {
+    note: "PEP 487's __set_name__ lets a descriptor learn its attribute name at class-creation time.",
+    code: `# v1.26: PEP 487 __set_name__ is supported.
+class Tagged:
+    def __set_name__(self, owner, name):
+        self.label = f"{owner.__name__}.{name}"
+    def __get__(self, obj, objtype=None):
+        return f"<{self.label}>"
+
+class Box:
+    a = Tagged()
+    b = Tagged()
+
+box = Box()
+print(box.a)   # -> <Box.a>
+print(box.b)   # -> <Box.b>
+`
+  },
+  format: {
+    note: 'New in v1.26: digit grouping with underscores in str.format / f-strings using :_b, :_o and :_x.',
+    code: `# v1.26: new :_b / :_o / :_x grouping specifiers.
+n = 0xDEADBEEF
+print(f"hex grouped:    {n:_x}")
+print(f"binary grouped: {n:_b}")
+print(f"octal grouped:  {n:_o}")
+print(f"decimal:        {n:_d}")   # already supported, included for context
+`
+  },
+  array: {
+    note: 'In v1.26, array() can be extended from any iterable, not just objects supporting the buffer protocol.',
+    code: `# v1.26: array() now accepts any iterable.
+from array import array
+
+a = array("i", range(5))
+print(a)
+
+def gen():
+    for i in range(3):
+        yield i * 10
+
+a.extend(gen())
+print(a)         # array('i', [0, 1, 2, 3, 4, 0, 10, 20])
+`
+  },
+  slice: {
+    note: 'v1.26 avoids heap-allocating slice objects when subscripting bytearray/memoryview -- so this works even with the GC heap locked.',
+    code: `# v1.26: slice subscripts on bytearray no longer allocate.
+import micropython, gc
+
+buf = bytearray(b"\\x00" * 16)
+
+# Lock the heap entirely -- no allocations allowed.
+micropython.heap_lock()
+try:
+    buf[2:6] = b"\\xde\\xad\\xbe\\xef"
+    print("After heap-locked slice assign:", bytes(buf))
+finally:
+    micropython.heap_unlock()
+
+print("Sanity:", bytes(buf))
+`
+  },
+};
+
+function initLanguagePicker() {
+  const picker = document.getElementById('lang-picker');
+  const editor = document.getElementById('lang-editor');
+  const note = document.getElementById('lang-note');
+  const reset = document.getElementById('lang-reset');
+  if (!picker || !editor) return;
+
+  function load(key) {
+    const ex = LANG_EXAMPLES[key];
+    if (!ex) return;
+    editor.value = ex.code;
+    note.textContent = ex.note;
+  }
+  picker.addEventListener('change', () => load(picker.value));
+  reset.addEventListener('click', () => load(picker.value));
+  load(picker.value);
+}

--- a/micropython-v1.27/index.html
+++ b/micropython-v1.27/index.html
@@ -1,0 +1,637 @@
+---
+layout: release-notes
+title: MicroPython v1.27.0 Release Notes
+version: v1.27.0
+pyscript: true
+page_css: /micropython-v1.27/v1.27.css
+page_js: /micropython-v1.27/v1.27.js
+
+hero:
+  version: "v1.27"
+  tagline: "Three new MCU families, formal port Tier levels, and a unified REPL on every port."
+  date: "December 10, 2025"
+
+summary_cards:
+  - { icon: "&#127894;",  title: "Port Tiers",    desc: "20 ports, 4 formal tiers", target: "tiers" }
+  - { icon: "&#128187;",  title: "ESP32-C5 / P4", desc: "Standalone and co-processor", target: "espnew" }
+  - { icon: "&#9889;",    title: "STM32U5",       desc: "Low-power, high-performance",  target: "stm32u5" }
+  - { icon: "&#128241;",  title: "Unified REPL",  desc: "Raw REPL on unix and windows", target: "repl" }
+
+stats:
+  - { value: 49, label: "Contributors" }
+  - { value: 15, label: "Timezones" }
+  - { value: 14, label: "New Boards" }
+
+mpy_banner:
+  headline: "The language demos on this page run real MicroPython in your browser."
+  body: "MicroPython is compiled to WebAssembly via PyScript and executes live as the page loads &mdash; no server required."
+
+toc:
+  - { id: "tiers",    label: "Port Tiers" }
+  - { id: "espnew",   label: "ESP32-C5 / P4" }
+  - { id: "stm32u5",  label: "STM32U5" }
+  - { id: "repl",     label: "Unified REPL" }
+  - { id: "timers",   label: "Hard IRQ Timers" }
+  - { id: "language", label: "Language Tweaks" }
+  - { id: "highlights", label: "Highlights" }
+
+boards:
+  summary: "14 new board definitions across 3 ports."
+  groups:
+    - port: "esp32"
+      boards:
+        - "ESP32_GENERIC_C2 / FLASH_2M"
+        - "ESP32_GENERIC_C5"
+        - "ESP32_GENERIC_P4"
+        - "ESP32_GENERIC_P4 / C5_WIFI"
+        - "ESP32_GENERIC_P4 / C6_WIFI"
+        - "SIL_MANT1S"
+        - "SOLDERED_NULA_MINI"
+    - port: "stm32"
+      boards:
+        - "NUCLEO_H7A3ZI_Q"
+        - "NUCLEO_U5A5ZJ_Q"
+        - "STM32F469DISC"
+        - "WEACTSTUDIO_MINI_STM32H743"
+    - port: "zephyr"
+      boards:
+        - "pocketbeagle_2"
+        - "xiao_ble_nrf52840_sense"
+        - "mimxrt1020_evk"
+
+numbers:
+  summary: "v1.27 in numbers. esp32 grew most, driven by ESP-IDF v5.5.1 and the new RMT API."
+  cards:
+    - { value: 49, label: "Contributors" }
+    - { value: 15, label: "Timezones" }
+    - { value: 14, label: "New Boards" }
+  code_size:
+    title: "Code size delta vs v1.26 (.text section, bytes)"
+    rows:
+      - { port: "esp32",        delta_bytes: 36210, bar_pct: 100, tooltip: "+2.12% &mdash; IDF 5.5.1 + new RMT API" }
+      - { port: "rp2 (PICO)",   delta_bytes: 3836,  bar_pct: 11, tooltip: "+1.12% &mdash; hashlib.md5, TinyUSB update" }
+      - { port: "unix x64",     delta_bytes: 2608,  bar_pct: 7,  tooltip: "+0.31% &mdash; standard bare-metal REPL" }
+      - { port: "rp2 (PICO_W)", delta_bytes: 1020,  bar_pct: 3,  tooltip: "+0.11% &mdash; TinyUSB update" }
+      - { port: "minimal x86",  delta_bytes: 867,   bar_pct: 3,  tooltip: "+0.47% &mdash; sys module enabled" }
+      - { port: "samd",         delta_bytes: 596,   bar_pct: 2,  tooltip: "+0.22% &mdash; TinyUSB update" }
+      - { port: "esp8266",      delta_bytes: 472,   bar_pct: 2,  tooltip: "+0.07% &mdash; hard IRQ timer callbacks" }
+      - { port: "mimxrt",       delta_bytes: 280,   bar_pct: 1,  tooltip: "+0.08% &mdash; TinyUSB, re start/end" }
+      - { port: "nrf",          delta_bytes: 124,   bar_pct: 1,  tooltip: "+0.07% &mdash; SPI baudrate print, UART timeouts" }
+      - { port: "cc3200",       delta_bytes: 112,   bar_pct: 1,  tooltip: "+0.06% &mdash; leading-zero formatting, re start/end" }
+      - { port: "renesas-ra",   delta_bytes: 104,   bar_pct: 1,  tooltip: "+0.02% &mdash; leading-zero formatting" }
+      - { port: "stm32",        delta_bytes: -68,   bar_pct: 1,  tooltip: "-0.02% &mdash; soft IRQ refactor offset gains" }
+      - { port: "bare-arm",     delta_bytes: -180,  bar_pct: 1,  tooltip: "-0.32% &mdash; mul-overflow intrinsic" }
+  contributors: |
+    Alessandro Gatti, Alex Tran, Andrew Leech, Angus Gratton, Anson Mansfield,
+    Ayush Singh, Chris Liechti, Chris Mason, Chris Webb, Christian Clauss,
+    Craftzman7, Damien George, Dani&euml;l van de Giessen, David Lechner,
+    David Schneider, Dryw Wade, Elvis Pfutzenreuter, ennyKey, Florent, garywill,
+    iabdalkader, Ihor Nehrutsa, Jared Hancock, Jeff Epler, Jimisola Laursen,
+    John Smith, Jos Verlinde, Josip &Scaron;imun Ku&ccaron;i, Kwabena W. Agyeman,
+    Matt Trentini, Maureen Helm, Meir Armon, Mike Tolkachev, Mike Wang, Ned Konz,
+    Patrick Van Oosterwijck, Peter Harper, Phil Howard, robert-hh, Steve Sanbeg,
+    stijn, Thomas Watson, Tico06, Vdragon, Vincent1-python, Yanfeng Liu,
+    Yilin Sun, yuan_mo, Yuuki NAGAO.
+
+pyscript_block: |
+  from pyscript import document, when
+  import sys
+
+  def run_editor(code_id, out_id):
+      code = document.querySelector("#" + code_id).value
+      out_el = document.querySelector("#" + out_id)
+      out_el.classList.remove("has-error")
+      lines = []
+      def _print(*args, sep=" ", end="\n"):
+          lines.append(sep.join(str(a) for a in args) + end)
+      try:
+          exec(code, {"print": _print})
+          output = "".join(lines) or "(no output)"
+      except Exception as e:
+          output = type(e).__name__ + ": " + str(e)
+          out_el.classList.add("has-error")
+      out_el.innerText = output
+
+  @when("click", "#lang-run")
+  def _r_lang(ev):
+      run_editor("lang-editor", "lang-output")
+
+  for s in document.querySelectorAll(".mpy-status"):
+      s.innerText = f"MicroPython {sys.version} ready"
+---
+
+<!-- ===== SECTION: PORT TIERS ===== -->
+<section class="section" id="tiers">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>Port Tier Levels</h2>
+    <p class="section-desc">
+      MicroPython supports more than twenty ports. v1.27 formalises that landscape:
+      every port is now classified into one of <strong>four Tier levels</strong>, setting
+      expectations for how mature it is, how actively it's tested, and what level of
+      support contributors should expect. The classification also lowers the bar for new
+      ports to land &mdash; they can enter at a low Tier and graduate upward.
+    </p>
+  </div>
+
+  <div class="demo-container">
+    <div class="demo-label">Interactive Demo &mdash; Click a Tier to Filter</div>
+
+    <div class="tier-legend">
+      <button class="tier-legend-btn active" data-tier="all">All ports</button>
+      <button class="tier-legend-btn" data-tier="1">
+        <span class="tier-swatch tier-1"></span>Tier 1 &mdash; mature, fully tested
+      </button>
+      <button class="tier-legend-btn" data-tier="2">
+        <span class="tier-swatch tier-2"></span>Tier 2 &mdash; supported
+      </button>
+      <button class="tier-legend-btn" data-tier="3">
+        <span class="tier-swatch tier-3"></span>Tier 3 &mdash; built in CI
+      </button>
+      <button class="tier-legend-btn" data-tier="M">
+        <span class="tier-swatch tier-M"></span>Tier M &mdash; maintenance
+      </button>
+    </div>
+
+    <div class="tier-grid" id="tier-grid">
+      <!-- Tier 1 -->
+      <div class="tier-node tier-1" data-tier="1" data-port="esp32" data-vendor="true">
+        <div class="tier-node-name">esp32</div>
+        <div class="tier-node-target">Espressif ESP32 family</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+      <div class="tier-node tier-1" data-tier="1" data-port="mimxrt">
+        <div class="tier-node-name">mimxrt</div>
+        <div class="tier-node-target">NXP i.MX RT</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+      <div class="tier-node tier-1" data-tier="1" data-port="rp2">
+        <div class="tier-node-name">rp2</div>
+        <div class="tier-node-target">Raspberry Pi RP2040 / RP2350</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+      <div class="tier-node tier-1" data-tier="1" data-port="samd">
+        <div class="tier-node-name">samd</div>
+        <div class="tier-node-target">Microchip SAMD21 / SAMD51</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+      <div class="tier-node tier-1" data-tier="1" data-port="stm32">
+        <div class="tier-node-name">stm32</div>
+        <div class="tier-node-target">ST STM32 (F0/F4/F7/G0/G4/H5/H7/L0/L1/L4/N6/WB/WL)</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+      <div class="tier-node tier-1" data-tier="1" data-port="unix">
+        <div class="tier-node-name">unix</div>
+        <div class="tier-node-target">Linux, BSD, macOS, WSL</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+      <div class="tier-node tier-1" data-tier="1" data-port="windows">
+        <div class="tier-node-name">windows</div>
+        <div class="tier-node-target">Microsoft Windows</div>
+        <div class="tier-node-tag">Tier 1</div>
+      </div>
+
+      <!-- Tier 2 -->
+      <div class="tier-node tier-2" data-tier="2" data-port="alif">
+        <div class="tier-node-name">alif</div>
+        <div class="tier-node-target">Alif Ensemble (E3, E7)</div>
+        <div class="tier-node-tag">Tier 2</div>
+      </div>
+      <div class="tier-node tier-2" data-tier="2" data-port="embed">
+        <div class="tier-node-name">embed</div>
+        <div class="tier-node-target">Embeddable .c/.h sources</div>
+        <div class="tier-node-tag">Tier 2</div>
+      </div>
+      <div class="tier-node tier-2" data-tier="2" data-port="nrf">
+        <div class="tier-node-name">nrf</div>
+        <div class="tier-node-target">Nordic nRF51 / nRF52</div>
+        <div class="tier-node-tag">Tier 2</div>
+      </div>
+      <div class="tier-node tier-2" data-tier="2" data-port="renesas-ra">
+        <div class="tier-node-name">renesas-ra</div>
+        <div class="tier-node-target">Renesas RA family</div>
+        <div class="tier-node-tag">Tier 2</div>
+      </div>
+      <div class="tier-node tier-2" data-tier="2" data-port="webassembly">
+        <div class="tier-node-name">webassembly</div>
+        <div class="tier-node-target">Browsers and Node.js (PyScript runs here!)</div>
+        <div class="tier-node-tag">Tier 2</div>
+      </div>
+      <div class="tier-node tier-2" data-tier="2" data-port="zephyr">
+        <div class="tier-node-name">zephyr</div>
+        <div class="tier-node-target">Zephyr RTOS</div>
+        <div class="tier-node-tag">Tier 2</div>
+      </div>
+
+      <!-- Tier 3 -->
+      <div class="tier-node tier-3" data-tier="3" data-port="cc3200">
+        <div class="tier-node-name">cc3200</div>
+        <div class="tier-node-target">TI CC3200</div>
+        <div class="tier-node-tag">Tier 3</div>
+      </div>
+      <div class="tier-node tier-3" data-tier="3" data-port="esp8266">
+        <div class="tier-node-name">esp8266</div>
+        <div class="tier-node-target">Espressif ESP8266</div>
+        <div class="tier-node-tag">Tier 3</div>
+      </div>
+      <div class="tier-node tier-3" data-tier="3" data-port="pic16bit">
+        <div class="tier-node-name">pic16bit</div>
+        <div class="tier-node-target">Microchip PIC 16-bit</div>
+        <div class="tier-node-tag">Tier 3</div>
+      </div>
+      <div class="tier-node tier-3" data-tier="3" data-port="powerpc">
+        <div class="tier-node-name">powerpc</div>
+        <div class="tier-node-target">IBM PowerPC (incl. Microwatt)</div>
+        <div class="tier-node-tag">Tier 3</div>
+      </div>
+
+      <!-- Tier M -->
+      <div class="tier-node tier-M" data-tier="M" data-port="bare-arm">
+        <div class="tier-node-name">bare-arm</div>
+        <div class="tier-node-target">Minimum config &mdash; tracks core size</div>
+        <div class="tier-node-tag">Tier M</div>
+      </div>
+      <div class="tier-node tier-M" data-tier="M" data-port="minimal">
+        <div class="tier-node-name">minimal</div>
+        <div class="tier-node-target">Reference for new ports</div>
+        <div class="tier-node-tag">Tier M</div>
+      </div>
+      <div class="tier-node tier-M" data-tier="M" data-port="qemu">
+        <div class="tier-node-name">qemu</div>
+        <div class="tier-node-target">Cortex-A/M, RISC-V 32 &amp; 64 emulation</div>
+        <div class="tier-node-tag">Tier M</div>
+      </div>
+    </div>
+
+    <div class="tier-summary">
+      <div><strong id="tier-count-1">7</strong> Tier 1</div>
+      <div><strong id="tier-count-2">6</strong> Tier 2</div>
+      <div><strong id="tier-count-3">4</strong> Tier 3</div>
+      <div><strong id="tier-count-M">3</strong> Tier M</div>
+      <div class="tier-summary-total">= <strong>20</strong> total</div>
+    </div>
+
+    <p class="tier-note">
+      Note: <code>esp32</code> has ongoing financial support from Espressif.
+      Full tier definitions live in the
+      <a href="https://docs.micropython.org/en/latest/develop/support_tiers.html" target="_blank">MicroPython support tiers documentation</a>.
+    </p>
+  </div>
+</section>
+
+<!-- ===== SECTION: ESP32-C5 / P4 ===== -->
+<section class="section" id="espnew">
+  <div class="section-header">
+    <span class="section-badge new">New MCUs</span>
+    <h2>ESP32-C5 &amp; ESP32-P4 &mdash; standalone or paired</h2>
+    <p class="section-desc">
+      v1.27 adds two new RISC-V ESP32 family members. The <strong>ESP32-P4</strong>
+      is a higher-performance application processor that has no built-in radio &mdash;
+      so for wireless, it's paired with a <strong>C5</strong> (WiFi 6) or <strong>C6</strong>
+      (WiFi 4 + 802.15.4) co-processor. Board profiles ship for all three configurations.
+    </p>
+  </div>
+
+  <div class="demo-container">
+    <div class="demo-label">Interactive Demo &mdash; ESP32-P4 Configurations</div>
+
+    <div class="esp-config-toggle">
+      <button class="active" data-config="standalone">P4 standalone</button>
+      <button data-config="c5wifi">P4 + C5 (WiFi 6)</button>
+      <button data-config="c6wifi">P4 + C6 (WiFi 4 + 802.15.4)</button>
+      <button data-config="c5">C5 standalone</button>
+    </div>
+
+    <div class="esp-stage">
+      <svg class="esp-svg" viewBox="0 0 600 280" preserveAspectRatio="xMidYMid meet" id="esp-svg">
+        <!-- Main MCU (always present) -->
+        <rect x="160" y="80" width="160" height="120" class="esp-mcu" id="esp-main"/>
+        <text x="240" y="120" class="esp-mcu-label" id="esp-main-label">ESP32-P4</text>
+        <text x="240" y="142" class="esp-mcu-sublabel" id="esp-main-sub1">Dual-core RV32</text>
+        <text x="240" y="158" class="esp-mcu-sublabel" id="esp-main-sub2">High-performance</text>
+        <text x="240" y="180" class="esp-mcu-tag" id="esp-main-tag">Application processor</text>
+
+        <!-- Radio co-processor (visible in paired modes) -->
+        <g id="esp-radio-group" style="display:none;">
+          <line x1="320" y1="140" x2="430" y2="140" class="esp-bus-line"/>
+          <text x="375" y="135" class="esp-bus-label">SDIO / SPI</text>
+          <rect x="430" y="100" width="120" height="80" class="esp-radio-mcu" id="esp-radio-mcu"/>
+          <text x="490" y="130" class="esp-radio-label" id="esp-radio-label">ESP32-C5</text>
+          <text x="490" y="148" class="esp-radio-sub" id="esp-radio-sub1">RV32 + WiFi 6</text>
+          <text x="490" y="164" class="esp-radio-sub" id="esp-radio-sub2">Co-processor</text>
+        </g>
+
+        <!-- Antenna (for radio modes) -->
+        <g id="esp-antenna" style="display:none;">
+          <path d="M 490 100 L 480 70 L 500 70 Z" class="esp-antenna-path"/>
+          <line x1="490" y1="70" x2="490" y2="50" class="esp-antenna-line"/>
+          <circle cx="490" cy="48" r="3" class="esp-antenna-tip"/>
+        </g>
+
+        <!-- Standalone-mode 'no radio' annotation -->
+        <g id="esp-noradio" style="display:none;">
+          <text x="490" y="140" class="esp-no-radio">no radio</text>
+        </g>
+      </svg>
+    </div>
+
+    <div class="esp-info">
+      <div class="esp-info-card">
+        <div class="esp-info-label">Use case</div>
+        <div class="esp-info-value" id="esp-info-usecase">High-performance compute, no wireless required</div>
+      </div>
+      <div class="esp-info-card">
+        <div class="esp-info-label">Board profile</div>
+        <div class="esp-info-value" id="esp-info-board">ESP32_GENERIC_P4</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">A new pattern</div>
+    Pairing a high-performance compute MCU with a small wireless co-processor is a
+    departure from the usual all-in-one ESP32 design. The C5 also ships standalone
+    with its own application code &mdash; <code>ESP32_GENERIC_C5</code>.
+  </div>
+</section>
+
+<!-- ===== SECTION: STM32U5 ===== -->
+<section class="section" id="stm32u5">
+  <div class="section-header">
+    <span class="section-badge new">New MCU</span>
+    <h2>STM32U5xx series</h2>
+    <p class="section-desc">
+      Support for STMicroelectronics' low-power, high-performance U5 series &mdash;
+      Cortex-M33 with TrustZone, generous RAM, and competitive power numbers. v1.27
+      brings up USB, ADC, DAC, UART, I2C, SPI and RTC, with a board profile for the
+      <code>NUCLEO-U5A5ZJ-Q</code>.
+    </p>
+  </div>
+
+  <div class="mcu-spec-cards">
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>STM32U5</h3>
+        <span class="badge active">Cortex-M33</span>
+      </div>
+      <div class="mcu-spec-strip">
+        <div><span class="mcu-spec-num">M33</span> + TZ</div>
+        <div><span class="mcu-spec-num">low</span> power</div>
+        <div><span class="mcu-spec-num">USB</span> +DAC +RTC</div>
+      </div>
+      <p class="mcu-spec-desc">
+        Targeted at battery-powered IoT applications. v1.27's port supports the core
+        peripherals; expect more (Ethernet, advanced power modes) in subsequent
+        releases. STM32 also gets the F469 disco board, NUCLEO-H7A3ZI-Q, and a
+        WeAct mini H743 in this release.
+      </p>
+      <div class="mcu-spec-boards">
+        <span class="board-chip">NUCLEO_U5A5ZJ_Q</span>
+      </div>
+    </div>
+
+    <div class="mcu-spec-card">
+      <div class="mcu-spec-header">
+        <h3>STM32 family additions</h3>
+        <span class="badge active">v1.27 cross-cutting</span>
+      </div>
+      <ul class="stm32-bullets">
+        <li><strong>STM32G0xx</strong> &mdash; DAC support; ADC, Timer(4), RTC wakeup fixes.</li>
+        <li><strong>STM32G4xx</strong> &mdash; hardware I2C (was bit-banged).</li>
+        <li><strong>STM32L4xx</strong> &mdash; <code>I2CTarget</code> (the v1.26 feature, now on L4).</li>
+        <li><strong>STM32N6xx</strong> &mdash; LAN works, including gigabit Ethernet via RTL8211 PHY.</li>
+        <li><strong>Optional TinyUSB</strong> &mdash; opt-in TinyUSB stack alongside the existing STM USB stack.
+            Eventually the default; allows defining USB devices in Python.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ===== SECTION: UNIFIED REPL ===== -->
+<section class="section" id="repl">
+  <div class="section-header">
+    <span class="section-badge improved">Improved</span>
+    <h2>Unified REPL on unix &amp; windows</h2>
+    <p class="section-desc">
+      The unix and windows ports' main REPL loop has been replaced with the same
+      <code>pyexec</code> code that all bare-metal ports use. Behaviour is now
+      consistent across the entire MicroPython family &mdash; and crucially,
+      <strong>raw REPL is now supported on unix and windows</strong>, which means
+      <code>mpremote</code> works against a unix MicroPython build the same way it
+      works against a board.
+    </p>
+  </div>
+
+  <div class="repl-side-by-side">
+    <div class="repl-pane">
+      <div class="repl-pane-label">Bare metal &mdash; works since forever</div>
+<pre class="repl-pre"><span class="cmt">$ mpremote connect /dev/ttyACM0</span>
+&gt;&gt;&gt; <span class="kw">import</span> sys
+&gt;&gt;&gt; <span class="bi">print</span>(sys.platform)
+rp2
+&gt;&gt;&gt; </pre>
+    </div>
+    <div class="repl-pane">
+      <div class="repl-pane-label">Unix port &mdash; <strong>now works the same way in v1.27</strong></div>
+<pre class="repl-pre"><span class="cmt">$ mpremote connect ./build-standard/micropython</span>
+&gt;&gt;&gt; <span class="kw">import</span> sys
+&gt;&gt;&gt; <span class="bi">print</span>(sys.platform)
+linux
+&gt;&gt;&gt; </pre>
+    </div>
+  </div>
+
+  <div class="callout">
+    <div class="callout-title">Why it matters</div>
+    The unix port is widely used for testing, scripting and CI. With raw-REPL parity,
+    every workflow that uses <code>mpremote</code> against a board now works against
+    a unix build too &mdash; including <code>mpremote run</code>, <code>mpremote cp</code>,
+    and the test harness.
+  </div>
+</section>
+
+<!-- ===== SECTION: HARD IRQ TIMERS ===== -->
+<section class="section" id="timers">
+  <div class="section-header">
+    <span class="section-badge new">Cross-port</span>
+    <h2>Hard IRQ Timer Callbacks &mdash; almost everywhere</h2>
+    <p class="section-desc">
+      <code>machine.Timer(...).init(callback=fn, hard=True)</code> now runs your
+      callback inside the actual hardware interrupt context (no scheduler hop), so
+      the latency is sub-microsecond. v1.27 brings hard-IRQ timer support to most
+      ports. <strong>esp32 remains soft-IRQ only.</strong>
+    </p>
+  </div>
+
+  <div class="port-matrix">
+    <div class="port-chip"><span class="check">&#10003;</span> alif</div>
+    <div class="port-chip"><span class="check">&#10003;</span> mimxrt</div>
+    <div class="port-chip"><span class="check">&#10003;</span> nrf</div>
+    <div class="port-chip"><span class="check">&#10003;</span> renesas-ra</div>
+    <div class="port-chip"><span class="check">&#10003;</span> rp2</div>
+    <div class="port-chip"><span class="check">&#10003;</span> samd</div>
+    <div class="port-chip"><span class="check">&#10003;</span> stm32</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> esp8266 (new)</div>
+    <div class="port-chip new-in-release"><span class="check">&#10003;</span> zephyr (new)</div>
+    <div class="port-chip" style="opacity: 0.6;">esp32 (soft only)</div>
+  </div>
+
+  <div class="code-block" style="margin-top:24px;">
+    <div class="code-header">
+      <span>main.py</span>
+      <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+    </div>
+<pre><span class="kw">from</span> machine <span class="kw">import</span> Timer
+
+<span class="kw">def</span> <span class="fn">on_tick</span>(t):
+    <span class="cmt"># Runs in ISR context: no allocation, no try/except, no print to UART</span>
+    pin.toggle()
+
+t = Timer(<span class="num">0</span>)
+t.init(freq=<span class="num">10_000</span>, callback=on_tick, hard=<span class="bi">True</span>)</pre>
+  </div>
+</section>
+
+<!-- ===== SECTION: LANGUAGE TWEAKS ===== -->
+<section class="section" id="language">
+  <div class="section-header">
+    <span class="section-badge new">New</span>
+    <h2>Python language tweaks</h2>
+    <p class="section-desc">
+      Four small core-language additions in v1.27. Pick one from the dropdown to load
+      the example into the editor, then run it live.
+    </p>
+  </div>
+
+  <div class="demo-container live-playground">
+    <div class="demo-label">
+      Live demo
+      <span class="pyscript-tag">PyScript</span>
+    </div>
+
+    <div class="example-picker-row">
+      <label for="lang-picker">Example:</label>
+      <select id="lang-picker" class="example-picker">
+        <option value="re_pos">re.match / search start &amp; end positions</option>
+        <option value="dict_views">bool() and len() on dict views</option>
+        <option value="custom_import">Relative imports in custom __import__</option>
+        <option value="grouping_lz">Leading-zero digit grouping</option>
+      </select>
+    </div>
+
+    <textarea class="mpy-code-editor" id="lang-editor" spellcheck="false"></textarea>
+    <div class="mpy-btn-row">
+      <button class="mpy-run-btn" id="lang-run">Run &#9654;</button>
+      <button class="mpy-clear-btn" id="lang-reset">Reset example</button>
+      <span class="mpy-status">Loading MicroPython&hellip;</span>
+    </div>
+    <div class="mpy-output" id="lang-output"></div>
+
+    <p class="playground-note" id="lang-note"></p>
+  </div>
+</section>
+
+<!-- ===== SECTION: HIGHLIGHTS ===== -->
+<section class="section" id="highlights">
+  <div class="section-header">
+    <h2>Highlights</h2>
+    <p class="section-desc">Other notable improvements in v1.27.</p>
+  </div>
+
+  <div class="highlights-grid">
+    <div class="highlight-card">
+      <span class="hl-icon">&#9989;</span>
+      <h3>Test suite + CI overhaul</h3>
+      <p>Auto-detect unicode/float/native, always run stress tests, ASan + UBSan
+        builds, full suite on unix-minimal and zephyr CI.</p>
+      <div class="hl-ports"><span class="hl-port-tag">tests</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128279;</span>
+      <h3>target_wiring.py</h3>
+      <p>Per-board test-wiring config in one file. <code>machine.UART</code> tests
+        already converted; pattern extends to other peripherals.</p>
+      <div class="hl-ports"><span class="hl-port-tag">tests</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128483;</span>
+      <h3>Drop Python 2.7 support</h3>
+      <p>EOL since January 2020. Build scripts and tools now require Python 3.</p>
+      <div class="hl-ports"><span class="hl-port-tag">build</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128268;</span>
+      <h3>esp32.wake_on_gpio()</h3>
+      <p>Wake the SoC from deep sleep via GPIO pins on the esp32 port.</p>
+      <div class="hl-ports"><span class="hl-port-tag">esp32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127911;</span>
+      <h3>I2S enabled on all ESP32-C6 boards</h3>
+      <p>Audio I/O ships out of the box on every C6 board profile.</p>
+      <div class="hl-ports"><span class="hl-port-tag">esp32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128296;</span>
+      <h3>RP2350 PIO + alt-function fixes</h3>
+      <p>PIO supports pin wrapping; RP2350B upper-bank pins now usable; alt
+        functions fixed for pins &gt; 31. New UART_AUX, XIP_CS1, CORESIGHT_TRACE
+        and HSTX alt functions.</p>
+      <div class="hl-ports"><span class="hl-port-tag">rp2</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127760;</span>
+      <h3>asyncio.start_server() IPv6</h3>
+      <p>The asyncio server can now bind IPv6 sockets directly.</p>
+      <div class="hl-ports"><span class="hl-port-tag">asyncio</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128202;</span>
+      <h3>RISC-V Zba opcodes</h3>
+      <p>Native emitter generates better 32-bit RISC-V code &mdash; useful on RP2350
+        in RV mode and on the ESP32-C-series.</p>
+      <div class="hl-ports"><span class="hl-port-tag">rv32</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#127817;</span>
+      <h3>QEMU adds RV64 + Cortex-M55</h3>
+      <p>New VIRT_RV64, MPS2_AN500 (M7) and MPS3_AN547 (M55) qemu boards
+        broaden architecture testing.</p>
+      <div class="hl-ports"><span class="hl-port-tag">qemu</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128269;</span>
+      <h3>Zephyr v4.2.0</h3>
+      <p>Zephyr port adds <code>machine.ADC</code>, native Zephyr filesystem
+        VFS, GC split heap, hard IRQ timer callbacks, sensor attribute
+        get/set, default-flash auto-format on boot.</p>
+      <div class="hl-ports"><span class="hl-port-tag">zephyr</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#9201;</span>
+      <h3>alif RTC + time_ns</h3>
+      <p><code>machine.RTC.datetime()</code> get/set, <code>time.time_ns()</code>,
+        plus USB device-address and SPI.init() fixes.</p>
+      <div class="hl-ports"><span class="hl-port-tag">alif</span></div>
+    </div>
+
+    <div class="highlight-card">
+      <span class="hl-icon">&#128737;</span>
+      <h3>ESP32 USB CDC stability</h3>
+      <p>TinyUSB ZLP fix that affected REPL reliability, plus a fix for blank
+        USB HID reports on PSRAM boards. <code>network.PPP</code> thread-safety
+        fixes.</p>
+      <div class="hl-ports"><span class="hl-port-tag">esp32</span></div>
+    </div>
+  </div>
+</section>

--- a/micropython-v1.27/v1.27.css
+++ b/micropython-v1.27/v1.27.css
@@ -1,0 +1,298 @@
+/* ============================================================
+   v1.27 page-specific styles
+   ESP32-C5/P4 family SVG, REPL side-by-side, STM32 bullets,
+   language picker (reuses v1.26's pattern).
+
+   The port-Tier chart styles live in assets/css/release-notes.css
+   since the same chart is reused on the /releases/ index page.
+   ============================================================ */
+
+/* ===== ESP32-C5 / P4 family ===== */
+.esp-config-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 4px;
+  margin-bottom: 20px;
+}
+.esp-config-toggle button {
+  flex: 1;
+  min-width: 120px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+.esp-config-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.esp-stage {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.esp-svg {
+  width: 100%;
+  height: 280px;
+  display: block;
+}
+
+.esp-mcu, .esp-radio-mcu {
+  fill: var(--bg-tertiary);
+  stroke: var(--accent);
+  stroke-width: 2;
+  rx: 8;
+}
+.esp-radio-mcu {
+  stroke: var(--accent-green);
+}
+.esp-mcu-label, .esp-radio-label {
+  fill: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 800;
+  text-anchor: middle;
+}
+.esp-mcu-sublabel, .esp-radio-sub {
+  fill: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  text-anchor: middle;
+}
+.esp-mcu-tag {
+  fill: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-anchor: middle;
+}
+
+.esp-bus-line {
+  stroke: var(--accent-green);
+  stroke-width: 2;
+  stroke-dasharray: 4 4;
+}
+.esp-bus-label {
+  fill: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-anchor: middle;
+}
+
+.esp-antenna-path {
+  fill: var(--accent-green);
+}
+.esp-antenna-line {
+  stroke: var(--accent-green);
+  stroke-width: 2;
+}
+.esp-antenna-tip {
+  fill: var(--accent-green);
+}
+
+.esp-no-radio {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-style: italic;
+  text-anchor: middle;
+}
+
+.esp-info {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.esp-info-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 18px;
+}
+.esp-info-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+.esp-info-value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+/* ===== STM32 bullets ===== */
+.stm32-bullets {
+  list-style: none;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+.stm32-bullets li {
+  padding: 4px 0;
+  position: relative;
+  padding-left: 20px;
+}
+.stm32-bullets li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  color: var(--accent);
+}
+.stm32-bullets strong {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+/* ===== REPL side-by-side ===== */
+.repl-side-by-side {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.repl-pane {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.repl-pane-label {
+  padding: 10px 14px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+}
+.repl-pane-label strong {
+  color: var(--accent-green);
+}
+.repl-pre {
+  padding: 14px 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+/* ===== Language Picker (matches v1.26 pattern) ===== */
+.example-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.example-picker-row label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+.example-picker {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  cursor: pointer;
+  flex: 1;
+  max-width: 360px;
+}
+.example-picker:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ===== MCU spec cards (mirrors v1.26 pattern) ===== */
+.mcu-spec-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+.mcu-spec-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  transition: all 0.2s ease;
+}
+.mcu-spec-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+.mcu-spec-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.mcu-spec-header h3 {
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+.mcu-spec-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+.mcu-spec-strip > div {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.mcu-spec-num {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+.mcu-spec-desc {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.mcu-spec-boards {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .repl-side-by-side { grid-template-columns: 1fr; }
+  .esp-info { grid-template-columns: 1fr; }
+  .tier-grid { grid-template-columns: 1fr 1fr; }
+  .esp-config-toggle { flex-direction: column; }
+  .esp-config-toggle button { min-width: 0; }
+}

--- a/micropython-v1.27/v1.27.js
+++ b/micropython-v1.27/v1.27.js
@@ -1,0 +1,186 @@
+/* ============================================================
+   v1.27 page-specific behaviour
+   Port-Tier chart filter, ESP32-C5/P4 configurator,
+   language example picker.
+   ============================================================ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  // initTierChart is provided by the shared release-notes.js
+  initEspConfig();
+  initLanguagePicker();
+});
+
+/* ===== ESP32-C5 / P4 configurator ===== */
+
+const ESP_CONFIGS = {
+  standalone: {
+    main: { label: 'ESP32-P4', sub1: 'Dual-core RV32', sub2: 'High-performance', tag: 'Application processor' },
+    radio: false,
+    board: 'ESP32_GENERIC_P4',
+    usecase: 'High-performance compute, no wireless required',
+  },
+  c5wifi: {
+    main: { label: 'ESP32-P4', sub1: 'Dual-core RV32', sub2: 'High-performance', tag: 'Application processor' },
+    radio: { label: 'ESP32-C5', sub1: 'RV32 + WiFi 6', sub2: 'Co-processor' },
+    board: 'ESP32_GENERIC_P4 / C5_WIFI',
+    usecase: 'Compute + WiFi 6 wireless via C5 co-processor',
+  },
+  c6wifi: {
+    main: { label: 'ESP32-P4', sub1: 'Dual-core RV32', sub2: 'High-performance', tag: 'Application processor' },
+    radio: { label: 'ESP32-C6', sub1: 'WiFi 4 + 802.15.4', sub2: 'Co-processor' },
+    board: 'ESP32_GENERIC_P4 / C6_WIFI',
+    usecase: 'Compute + WiFi 4 + Thread/Zigbee via C6 co-processor',
+  },
+  c5: {
+    main: { label: 'ESP32-C5', sub1: 'Single-core RV32', sub2: 'WiFi 6 + BLE 5', tag: 'WiFi 6 SoC' },
+    radio: false,
+    showAntennaOnMain: true,
+    board: 'ESP32_GENERIC_C5',
+    usecase: 'Standalone WiFi 6 SoC',
+  },
+};
+
+function initEspConfig() {
+  const buttons = document.querySelectorAll('.esp-config-toggle button');
+  if (!buttons.length) return;
+
+  const mainLabel = document.getElementById('esp-main-label');
+  const mainSub1 = document.getElementById('esp-main-sub1');
+  const mainSub2 = document.getElementById('esp-main-sub2');
+  const mainTag = document.getElementById('esp-main-tag');
+  const radioGroup = document.getElementById('esp-radio-group');
+  const radioLabel = document.getElementById('esp-radio-label');
+  const radioSub1 = document.getElementById('esp-radio-sub1');
+  const radioSub2 = document.getElementById('esp-radio-sub2');
+  const antenna = document.getElementById('esp-antenna');
+  const noRadio = document.getElementById('esp-noradio');
+  const board = document.getElementById('esp-info-board');
+  const usecase = document.getElementById('esp-info-usecase');
+
+  function setConfig(key) {
+    const cfg = ESP_CONFIGS[key];
+    if (!cfg) return;
+    buttons.forEach(b => b.classList.toggle('active', b.dataset.config === key));
+
+    mainLabel.textContent = cfg.main.label;
+    mainSub1.textContent = cfg.main.sub1;
+    mainSub2.textContent = cfg.main.sub2;
+    mainTag.textContent = cfg.main.tag;
+
+    if (cfg.radio) {
+      radioGroup.style.display = '';
+      antenna.style.display = '';
+      noRadio.style.display = 'none';
+      radioLabel.textContent = cfg.radio.label;
+      radioSub1.textContent = cfg.radio.sub1;
+      radioSub2.textContent = cfg.radio.sub2;
+      // Move antenna over the radio MCU
+      antenna.setAttribute('transform', '');
+    } else if (cfg.showAntennaOnMain) {
+      // Standalone C5 - antenna on the main MCU
+      radioGroup.style.display = 'none';
+      antenna.style.display = '';
+      noRadio.style.display = 'none';
+      // Translate antenna from x=490 to x=240 (over the main MCU)
+      antenna.setAttribute('transform', 'translate(-250, 0)');
+    } else {
+      // P4 standalone, no radio
+      radioGroup.style.display = 'none';
+      antenna.style.display = 'none';
+      noRadio.style.display = '';
+    }
+
+    board.textContent = cfg.board;
+    usecase.textContent = cfg.usecase;
+  }
+
+  buttons.forEach(b => b.addEventListener('click', () => setConfig(b.dataset.config)));
+  setConfig('standalone');
+}
+
+/* ===== Language Example Picker ===== */
+
+const LANG_EXAMPLES = {
+  re_pos: {
+    note: 'New in v1.27: re.match() and re.search() accept start and end position arguments, matching CPython.',
+    code: `# v1.27: start and end positions for re.match / re.search.
+import re
+
+text = "abc123def456"
+pattern = re.compile(r"\\d+")
+
+# Match starting from position 6 (after "abc123def")
+m = pattern.search(text, 6)
+print("From pos 6:", m.group(), "at", m.start(), "to", m.end())
+
+# Bound the search to positions 0..6 -- only first number matches
+m2 = pattern.search(text, 0, 6)
+print("Pos 0..6:", m2.group())
+
+# Without bounds: original behaviour
+m3 = pattern.search(text)
+print("Default:", m3.group())
+`
+  },
+  dict_views: {
+    note: 'v1.27 supports bool() and len() on dict views (.keys(), .values(), .items()) -- matches CPython, simplifies portable code.',
+    code: `# v1.27: bool() and len() work on dict views.
+d = {"a": 1, "b": 2, "c": 3}
+
+print("keys length:  ", len(d.keys()))
+print("values truthy?", bool(d.values()))
+print("items length: ", len(d.items()))
+
+empty = {}
+print("empty.keys() truthy?", bool(empty.keys()))   # False
+print("empty.items() len:  ", len(empty.items()))   # 0
+`
+  },
+  custom_import: {
+    note: 'v1.27 lets a user-defined __import__ callback handle relative imports correctly. Useful for sandboxes and overlay filesystems.',
+    code: `# v1.27: relative imports route through custom __import__.
+import builtins
+real_import = builtins.__import__
+
+def loud_import(name, globals=None, locals=None, fromlist=(), level=0):
+    print(f"[trace] __import__({name!r}, level={level}, fromlist={fromlist!r})")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = loud_import
+
+# Relative imports now invoke the hook -- in v1.26 they bypassed it.
+exec(compile("from . import sys", "<demo>", "exec"), {"__name__": "pkg.mod", "__package__": "pkg"})
+
+builtins.__import__ = real_import
+`
+  },
+  grouping_lz: {
+    note: 'v1.27 fixes leading-zero formatting with grouping specifiers -- "{:_08x}" now zero-pads then groups, just like CPython.',
+    code: `# v1.27: leading zeros + grouping work together.
+n = 0xABCD
+
+print(f"{n:_08x}")   # 0000_abcd  -- pads first, then groups
+print(f"{n:_08b}")   # 1010_1011_1100_1101 (or padded form for smaller n)
+print(f"{42:_08d}")  # 00_000_042
+print(f"{42:_08o}")  # 00_000_052
+`
+  },
+};
+
+function initLanguagePicker() {
+  const picker = document.getElementById('lang-picker');
+  const editor = document.getElementById('lang-editor');
+  const note = document.getElementById('lang-note');
+  const reset = document.getElementById('lang-reset');
+  if (!picker || !editor) return;
+
+  function load(key) {
+    const ex = LANG_EXAMPLES[key];
+    if (!ex) return;
+    editor.value = ex.code;
+    note.textContent = ex.note;
+  }
+  picker.addEventListener('change', () => load(picker.value));
+  reset.addEventListener('click', () => load(picker.value));
+  load(picker.value);
+}

--- a/releases/index.html
+++ b/releases/index.html
@@ -1,0 +1,712 @@
+---
+title: MicroPython Release Notes
+permalink: /releases/
+---
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MicroPython Interactive Release Notes</title>
+<link rel="stylesheet" href="{{ '/assets/css/release-notes.css' | relative_url }}">
+<style>
+/* Releases-index-specific overrides: no sidebar, wider main */
+.main {
+  margin-left: 0;
+  max-width: 1100px;
+  margin-right: auto;
+  margin-left: auto;
+  padding: 0 40px;
+}
+
+/* Release cards */
+.release-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  margin: 32px 0;
+}
+.release-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 28px;
+  transition: all 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+  position: relative;
+}
+.release-card.live:hover {
+  border-color: var(--accent);
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-lg);
+  text-decoration: none;
+}
+.release-card.upcoming {
+  opacity: 0.55;
+  cursor: default;
+}
+.release-card-version {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--accent);
+  letter-spacing: -0.5px;
+}
+.release-card-date {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.release-card-tagline {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  flex: 1;
+}
+.release-card-cta {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  margin-top: auto;
+}
+.release-card.upcoming .release-card-cta {
+  color: var(--text-muted);
+  font-style: italic;
+}
+.release-card-stamp {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.release-card-stamp.live {
+  color: var(--accent-green);
+  background: var(--accent-green-glow);
+  border: 1px solid var(--accent-green);
+}
+.release-card-stamp.upcoming {
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+/* Narrative timeline */
+.narrative-section {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 32px;
+  margin: 32px 0;
+}
+.narrative-section h2 {
+  font-size: 22px;
+  font-weight: 800;
+  margin-bottom: 8px;
+  letter-spacing: -0.3px;
+}
+.narrative-section > p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-bottom: 24px;
+}
+.narrative-arc {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 4px;
+  position: relative;
+}
+.narrative-arc::before {
+  content: '';
+  position: absolute;
+  left: 0; right: 0;
+  top: 36px;
+  height: 2px;
+  background: var(--border);
+  z-index: 0;
+}
+.narrative-step {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+}
+.narrative-step-version {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.narrative-step-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 4px solid var(--bg-card);
+  margin: 0 auto 12px;
+  display: block;
+}
+.narrative-step-content {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  padding: 0 4px;
+}
+.narrative-step-content strong {
+  color: var(--text-primary);
+  display: block;
+  margin-bottom: 2px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+/* Cross-cutting themes grid */
+.themes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+.theme-card {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px;
+}
+.theme-card h3 {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--text-primary);
+}
+.theme-card p {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Stub callout */
+.stub-banner {
+  background: var(--accent-glow);
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin: 24px 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.stub-banner strong { color: var(--accent); }
+
+@media (max-width: 768px) {
+  .narrative-arc {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .narrative-arc::before { display: none; }
+  .main { padding: 0 20px; }
+}
+</style>
+</head>
+<body>
+
+<button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">
+  <span id="theme-icon">&#9790;</span>
+</button>
+
+<div class="main">
+
+  <section class="hero" id="hero">
+    <div class="hero-badge">Interactive editions</div>
+    <h1>MicroPython <span>Release Notes</span></h1>
+    <p class="hero-tagline">
+      Browser-runnable, demo-driven walkthroughs of recent MicroPython releases &mdash;
+      built and maintained by the
+      <a href="https://melbournemicropythonmeetup.github.io/">Melbourne MicroPython Meetup</a>.
+    </p>
+    <p class="hero-date">Currently covering v1.24 &ndash; v1.28</p>
+  </section>
+
+  <div class="stub-banner">
+    <strong>All five pages live.</strong>
+    Interactive editions of the last five MicroPython releases (v1.24 through
+    v1.28) are now ready. Browse by release card below, or use the per-port
+    chart further down to find changes for your specific target.
+  </div>
+
+  <!-- Release cards -->
+  <div class="release-card-grid">
+
+    <a class="release-card live" href="{{ '/micropython-v1.28/' | relative_url }}">
+      <span class="release-card-stamp live">Live</span>
+      <div class="release-card-version">v1.28</div>
+      <div class="release-card-date">April 6, 2026</div>
+      <div class="release-card-tagline">
+        PWM on alif and stm32, a standardised <code>machine.CAN</code> API,
+        PEP 750 template strings, and the <code>weakref</code> module.
+      </div>
+      <div class="release-card-cta">Read the interactive notes &rarr;</div>
+    </a>
+
+    <a class="release-card live" href="{{ '/micropython-v1.27/' | relative_url }}">
+      <span class="release-card-stamp live">Live</span>
+      <div class="release-card-version">v1.27</div>
+      <div class="release-card-date">December 10, 2025</div>
+      <div class="release-card-tagline">
+        ESP32-C5, ESP32-P4 and STM32U5 support, formal port Tier levels,
+        unified pyexec REPL on unix/windows.
+      </div>
+      <div class="release-card-cta">Read the interactive notes &rarr;</div>
+    </a>
+
+    <a class="release-card live" href="{{ '/micropython-v1.26/' | relative_url }}">
+      <span class="release-card-stamp live">Live</span>
+      <div class="release-card-version">v1.26</div>
+      <div class="release-card-date">August 9, 2025</div>
+      <div class="release-card-tagline">
+        <code>machine.I2CTarget</code>, the float-accuracy overhaul, native emitter
+        wins, and the new STM32N6 and ESP32-C2 MCUs.
+      </div>
+      <div class="release-card-cta">Read the interactive notes &rarr;</div>
+    </a>
+
+    <a class="release-card live" href="{{ '/micropython-v1.25/' | relative_url }}">
+      <span class="release-card-stamp live">Live</span>
+      <div class="release-card-version">v1.25</div>
+      <div class="release-card-date">April 16, 2025</div>
+      <div class="release-card-tagline">
+        ROMFS / <code>VfsRom</code>, the brand-new alif port,
+        <code>@micropython.asm_rv32</code> inline RISC-V assembler, DTLS support.
+      </div>
+      <div class="release-card-cta">Read the interactive notes &rarr;</div>
+    </a>
+
+    <a class="release-card live" href="{{ '/micropython-v1.24/' | relative_url }}">
+      <span class="release-card-stamp live">Live</span>
+      <div class="release-card-version">v1.24</div>
+      <div class="release-card-date">October 26, 2024</div>
+      <div class="release-card-tagline">
+        RP2350 and ESP32-C6 support, RV32 native code emitter, common TinyUSB code,
+        <code>micropython.RingIO</code>.
+      </div>
+      <div class="release-card-cta">Read the interactive notes &rarr;</div>
+    </a>
+
+  </div>
+
+  <!-- Browse by Port -->
+  <section class="narrative-section">
+    <h2>Browse by Port</h2>
+    <p>
+      Every MicroPython port is classified into one of four Tier levels (formalised
+      in v1.27). Click a tier to filter the chart, or click any release chip on a
+      port to jump to that release's notes &mdash; useful when you only care about
+      what changed for a specific target.
+    </p>
+
+    <div class="tier-legend">
+      <button class="tier-legend-btn active" data-tier="all">All ports</button>
+      <button class="tier-legend-btn" data-tier="1">
+        <span class="tier-swatch tier-1"></span>Tier 1
+      </button>
+      <button class="tier-legend-btn" data-tier="2">
+        <span class="tier-swatch tier-2"></span>Tier 2
+      </button>
+      <button class="tier-legend-btn" data-tier="3">
+        <span class="tier-swatch tier-3"></span>Tier 3
+      </button>
+      <button class="tier-legend-btn" data-tier="M">
+        <span class="tier-swatch tier-M"></span>Tier M
+      </button>
+    </div>
+
+    <div class="tier-grid">
+      <!-- ===== Tier 1 ===== -->
+      <div class="tier-node tier-1" data-tier="1" data-port="esp32" data-vendor="true">
+        <div class="tier-node-name">esp32</div>
+        <div class="tier-node-target">Espressif ESP32 family</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.24/#newmcus' | relative_url }}">v1.24</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#highlights' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#espnew' | relative_url }}">v1.27</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.28/' | relative_url }}">v1.28</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-1" data-tier="1" data-port="mimxrt">
+        <div class="tier-node-name">mimxrt</div>
+        <div class="tier-node-target">NXP i.MX RT</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#highlights' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#i2ctarget' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#highlights' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-1" data-tier="1" data-port="rp2">
+        <div class="tier-node-name">rp2</div>
+        <div class="tier-node-target">Raspberry Pi RP2040 / RP2350</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.24/#newmcus' | relative_url }}">v1.24</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#asm' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#highlights' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#highlights' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-1" data-tier="1" data-port="samd">
+        <div class="tier-node-name">samd</div>
+        <div class="tier-node-target">Microchip SAMD21 / SAMD51</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#i2ctarget' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-1" data-tier="1" data-port="stm32">
+        <div class="tier-node-name">stm32</div>
+        <div class="tier-node-target">ST STM32 (F0/F4/F7/G0/G4/H5/H7/L0/L1/L4/N6/U5/WB/WL)</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.24/#highlights' | relative_url }}">v1.24</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#romfs' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#n6c2' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#stm32u5' | relative_url }}">v1.27</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.28/#pwm' | relative_url }}">v1.28</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-1" data-tier="1" data-port="unix">
+        <div class="tier-node-name">unix</div>
+        <div class="tier-node-target">Linux, BSD, macOS, WSL</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#repl' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-1" data-tier="1" data-port="windows">
+        <div class="tier-node-name">windows</div>
+        <div class="tier-node-target">Microsoft Windows</div>
+        <div class="tier-node-tag">Tier 1</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#repl' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <!-- ===== Tier 2 ===== -->
+      <div class="tier-node tier-2" data-tier="2" data-port="alif">
+        <div class="tier-node-name">alif</div>
+        <div class="tier-node-target">Alif Ensemble (E3, E7) &mdash; new in v1.25</div>
+        <div class="tier-node-tag">Tier 2</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#alif' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#highlights' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#highlights' | relative_url }}">v1.27</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.28/#pwm' | relative_url }}">v1.28</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-2" data-tier="2" data-port="embed">
+        <div class="tier-node-name">embed</div>
+        <div class="tier-node-target">Embeddable .c/.h sources</div>
+        <div class="tier-node-tag">Tier 2</div>
+        <div class="tier-node-releases">
+          <span class="tier-release-chip unbuilt" title="No notable per-port changes">&middot;</span>
+        </div>
+      </div>
+
+      <div class="tier-node tier-2" data-tier="2" data-port="nrf">
+        <div class="tier-node-name">nrf</div>
+        <div class="tier-node-target">Nordic nRF51 / nRF52</div>
+        <div class="tier-node-tag">Tier 2</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#highlights' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#highlights' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-2" data-tier="2" data-port="renesas-ra">
+        <div class="tier-node-name">renesas-ra</div>
+        <div class="tier-node-target">Renesas RA family</div>
+        <div class="tier-node-tag">Tier 2</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#dtls' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#floats' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-2" data-tier="2" data-port="webassembly">
+        <div class="tier-node-name">webassembly</div>
+        <div class="tier-node-target">Browsers and Node.js (PyScript runs here!)</div>
+        <div class="tier-node-tag">Tier 2</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.24/#language' | relative_url }}">v1.24</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#highlights' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.28/' | relative_url }}">v1.28</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-2" data-tier="2" data-port="zephyr">
+        <div class="tier-node-name">zephyr</div>
+        <div class="tier-node-target">Zephyr RTOS</div>
+        <div class="tier-node-tag">Tier 2</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.24/#highlights' | relative_url }}">v1.24</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#highlights' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#highlights' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#highlights' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <!-- ===== Tier 3 ===== -->
+      <div class="tier-node tier-3" data-tier="3" data-port="cc3200">
+        <div class="tier-node-name">cc3200</div>
+        <div class="tier-node-target">TI CC3200</div>
+        <div class="tier-node-tag">Tier 3</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-3" data-tier="3" data-port="esp8266">
+        <div class="tier-node-name">esp8266</div>
+        <div class="tier-node-target">Espressif ESP8266</div>
+        <div class="tier-node-tag">Tier 3</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.25/#romfs' | relative_url }}">v1.25</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#timers' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-3" data-tier="3" data-port="pic16bit">
+        <div class="tier-node-name">pic16bit</div>
+        <div class="tier-node-target">Microchip PIC 16-bit</div>
+        <div class="tier-node-tag">Tier 3</div>
+        <div class="tier-node-releases">
+          <span class="tier-release-chip unbuilt" title="No notable per-port changes">&middot;</span>
+        </div>
+      </div>
+
+      <div class="tier-node tier-3" data-tier="3" data-port="powerpc">
+        <div class="tier-node-name">powerpc</div>
+        <div class="tier-node-target">IBM PowerPC (incl. Microwatt)</div>
+        <div class="tier-node-tag">Tier 3</div>
+        <div class="tier-node-releases">
+          <span class="tier-release-chip unbuilt" title="No notable per-port changes">&middot;</span>
+        </div>
+      </div>
+
+      <!-- ===== Tier M ===== -->
+      <div class="tier-node tier-M" data-tier="M" data-port="bare-arm">
+        <div class="tier-node-name">bare-arm</div>
+        <div class="tier-node-target">Minimum config &mdash; tracks core size</div>
+        <div class="tier-node-tag">Tier M</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.26/#numbers' | relative_url }}">v1.26</a>
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#numbers' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-M" data-tier="M" data-port="minimal">
+        <div class="tier-node-name">minimal</div>
+        <div class="tier-node-target">Reference for new ports</div>
+        <div class="tier-node-tag">Tier M</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#numbers' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+
+      <div class="tier-node tier-M" data-tier="M" data-port="qemu">
+        <div class="tier-node-name">qemu</div>
+        <div class="tier-node-target">Cortex-A/M, RISC-V 32 &amp; 64 emulation</div>
+        <div class="tier-node-tag">Tier M</div>
+        <div class="tier-node-releases">
+          <a class="tier-release-chip" href="{{ '/micropython-v1.27/#highlights' | relative_url }}">v1.27</a>
+        </div>
+      </div>
+    </div>
+
+    <p class="tier-note">
+      <code>esp32</code> has ongoing financial support from Espressif (<code>*</code>).
+      Greyed-out chips link to release pages that haven't been written yet.
+      Full tier definitions are in the
+      <a href="https://docs.micropython.org/en/latest/develop/support_tiers.html" target="_blank">MicroPython support tiers documentation</a>.
+    </p>
+  </section>
+
+  <!-- machine.* standardisation arc -->
+  <section class="narrative-section">
+    <h2>The <code>machine.*</code> standardisation arc</h2>
+    <p>
+      The strongest cross-release storyline of the last five releases is the steady
+      push to standardise <code>machine</code>-module APIs across every port
+      &mdash; so portable code really does run unchanged.
+    </p>
+    <div class="narrative-arc">
+      <div class="narrative-step">
+        <div class="narrative-step-version">v1.24</div>
+        <span class="narrative-step-dot"></span>
+        <div class="narrative-step-content">
+          <strong>network.ipconfig()</strong>
+          IPv6-aware replacement for <code>ifconfig()</code>, plus portable
+          <code>network.PPP</code>.
+        </div>
+      </div>
+      <div class="narrative-step">
+        <div class="narrative-step-version">v1.25</div>
+        <span class="narrative-step-dot"></span>
+        <div class="narrative-step-content">
+          <strong>Default I2C/SPI/UART</strong>
+          Ports gain default-bus instances so cross-port code can drop the
+          <code>id</code> arg.
+        </div>
+      </div>
+      <div class="narrative-step">
+        <div class="narrative-step-version">v1.26</div>
+        <span class="narrative-step-dot"></span>
+        <div class="narrative-step-content">
+          <strong>I2CTarget &middot; Counter &middot; Encoder</strong>
+          New peripheral classes (target on 7 ports, counter/encoder on esp32 first).
+        </div>
+      </div>
+      <div class="narrative-step">
+        <div class="narrative-step-version">v1.27</div>
+        <span class="narrative-step-dot"></span>
+        <div class="narrative-step-content">
+          <strong>Hard-IRQ timers</strong>
+          <code>machine.Timer(hard=True)</code> available on most ports
+          (esp32 still soft-only).
+        </div>
+      </div>
+      <div class="narrative-step">
+        <div class="narrative-step-version">v1.28</div>
+        <span class="narrative-step-dot"></span>
+        <div class="narrative-step-content">
+          <strong>PWM &amp; CAN everywhere</strong>
+          <code>machine.PWM</code> on every Tier 1 &amp; 2 port, standardised
+          <code>machine.CAN</code> API across STM32 and friends.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Other recurring themes -->
+  <section class="narrative-section">
+    <h2>Other recurring threads</h2>
+    <p>Patterns worth noticing as you read across the releases.</p>
+    <div class="themes-grid">
+
+      <div class="theme-card">
+        <h3>RISC-V grows up</h3>
+        <p>
+          v1.24 ships the RV32 native emitter. v1.25 adds the
+          <code>asm_rv32</code> inline assembler. v1.26 optimises emitter output
+          across all archs including RV32. v1.27 adds Zba opcodes and an RV64 qemu
+          target. v1.28 picks up the Zcmp extension.
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>The ESP-IDF treadmill</h3>
+        <p>
+          v1.24 &rarr; IDF 5.2.2, v1.25 &rarr; 5.3/5.4, v1.26 &rarr; 5.4.2,
+          v1.27 &rarr; 5.5.1. Each bump moves esp32 firmware size noticeably and
+          unlocks new chips.
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>New STM32 families per release</h3>
+        <p>
+          STM32H7 octospi (v1.24), STM32N6 with ML accelerators (v1.26),
+          STM32U5 low-power and an STM32F469 disco board (v1.27).
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>Native &amp; viper emitter wins</h3>
+        <p>
+          Every release improves native code generation. Notable: Thumb v1
+          long-jump support (v1.26) lifted the function-size limit on RP2040,
+          and Xtensa LX3 inline opcodes near feature-parity (v1.26).
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>mpremote ergonomics</h3>
+        <p>
+          Hash-based recursive copy (v1.24), <code>rm -r</code> + <code>romfs</code>
+          (v1.25), <code>fs tree</code> + better <code>df</code> + ESP CDC
+          detection (v1.26), DTR/RTS quirks ironed out (v1.27).
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>Zephyr port maturation</h3>
+        <p>
+          Threading (v1.24), <code>Timer</code>/<code>WDT</code> (v1.25),
+          PWM/UART/SPI/I2C and <code>boot.py</code>/<code>main.py</code> at
+          startup (v1.26), ADC + native FS VFS (v1.27).
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>asyncio everywhere</h3>
+        <p>
+          v1.24 enables top-level <code>await</code> of <code>Task</code>/
+          <code>Event</code> on the webassembly port. v1.25 makes implicit awaits
+          implicit. v1.26 fixes scheduler edge cases. v1.27 adds IPv6 to
+          <code>asyncio.start_server()</code>.
+        </p>
+      </div>
+
+      <div class="theme-card">
+        <h3>TinyUSB consolidation</h3>
+        <p>
+          Common CDC code unified across esp32-S2/S3, mimxrt, renesas-ra, rp2 and
+          samd in v1.24. ESP32 native USB stabilises through v1.26.1. stm32 starts
+          adopting TinyUSB optionally in v1.27.
+        </p>
+      </div>
+
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/micropython/micropython/releases" target="_blank">All releases on GitHub</a>
+      <a href="https://docs.micropython.org/" target="_blank">Documentation</a>
+      <a href="https://micropython.org/download/" target="_blank">Downloads</a>
+      <a href="{{ '/' | relative_url }}">Meetup home</a>
+    </div>
+    <p style="font-size:12px; color:var(--text-muted); margin-top:24px;">
+      Built and maintained by the
+      <a href="https://melbournemicropythonmeetup.github.io/">Melbourne MicroPython Meetup</a>.
+      Live demos powered by <a href="https://pyscript.net/" target="_blank">PyScript</a>.
+    </p>
+  </footer>
+
+</div>
+
+<script src="{{ '/assets/js/release-notes.js' | relative_url }}"></script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Builds **five** feature-rich Jekyll release-notes pages (v1.24, v1.25, v1.26, v1.27, v1.28) following the visual pattern of the existing v1.28 page, plus a `/releases/` index that ties them together. Future releases inherit a complete template.

Headline interactive widgets per page:

- **v1.24** — RP2350 ARM ↔ RISC-V toggle (single-die two-architecture chip), live `RingIO` PyScript demo
- **v1.25** — ROMFS in-place execution diagram (two-MCU side-by-side, RAM counter ticks up only on the non-ROMFS side)
- **v1.26** — `machine.I2CTarget` SVG bus + bytearray grid, quadrature encoder canvas, animated float-accuracy 28% → 98.5% bars
- **v1.27** — port-Tier chart filtering 20 ports across 4 tiers, ESP32-P4 + co-processor configurator (standalone / +C5 / +C6 / C5-only)
- **v1.28** — unchanged from prior release

Plus per-page Tier-B PyScript playgrounds with example pickers covering every webassembly-runnable language addition across v1.24–v1.28.

## What's new

- `_layouts/release-notes.html` — front-matter-driven layout for every release page
- `_includes/release-notes/` — 8 reusable structural includes (hero, summary cards, stats ribbon, sidebar, mpy-banner, boards grid, by-the-numbers, footer)
- `assets/css/release-notes.css` (911 lines) and `assets/js/release-notes.js` — shared infrastructure including the port-Tier chart widget
- `micropython-v1.24/`, `micropython-v1.25/`, `micropython-v1.26/`, `micropython-v1.27/` — five-section pages each (~600 lines HTML + ~300 lines bespoke CSS + ~200 lines bespoke JS)
- `releases/index.html` — release cards, port-Tier nav widget, `machine.*` standardisation timeline, recurring-themes grid
- `_layouts/default.html` — adds *Release Notes* to the masthead nav
- `context/research/` — two markdown artifacts capturing the per-release digest and the v1.26 layout draft

## Approach notes

- The infrastructure was extracted incrementally: built v1.26 first, then v1.27, lifting the port-Tier chart into shared CSS/JS once it was needed in two places. v1.25 and v1.24 reused the established pattern.
- PyScript demos use the existing pattern from v1.28 (override `print` in the exec namespace rather than redirecting `sys.stdout`).
- Confirmed via the upstream `ports/webassembly/variants/pyscript/mpconfigvariant.h` that the variant ships at `MICROPY_CONFIG_ROM_LEVEL_FULL_FEATURES` — so `marshal` is **not** available (gated on `EVERYTHING`); the v1.25 page calls this out explicitly. `function.__code__`, `RingIO`, `heap_lock`/`heap_unlock`, f-strings and t-strings are all gated low enough to work.

## Test plan

- [ ] `just view` (Docker GitHub Pages) renders without Jekyll errors — front-matter YAML, multi-line `pyscript_block`, and HTML entities all need to round-trip cleanly
- [ ] Each release page loads, sidebar TOC scrollspy works, theme toggle redraws all canvas demos
- [ ] PyScript playgrounds: status flips to "MicroPython … ready"; Run executes the seeded code; Reset reloads the picked example
- [ ] v1.24 page: RP2350 ARM↔RISC-V toggle changes core labels, badge colour, and the three info cards
- [ ] v1.25 page: ROMFS demo animates a flash → RAM block on the left MCU; right MCU stays at 0 kB
- [ ] v1.26 page: I2CTarget Write button animates a packet across the bus and updates the bytearray grid; encoder dial drag updates count + traces
- [ ] v1.27 page: port-Tier filter buttons dim non-matching ports; ESP32-P4 toggle reveals/hides the radio co-processor and antenna
- [ ] `/releases/` page: all 20 port-tier nodes have working release-version chips that link to the right page sections
- [ ] Two open questions to verify in-browser:
  - [ ] v1.24 raw-fstring example survives the `editor.value = code` round-trip and produces correct regex match output
  - [ ] v1.26 `slice` example actually runs `micropython.heap_lock()` / `unlock()` without erroring in the pyscript variant